### PR TITLE
Guard almanac diagram sun altitude fallback

### DIFF
--- a/skins/Belchertown/almanac_diagram_data.inc
+++ b/skins/Belchertown/almanac_diagram_data.inc
@@ -1,3 +1,7 @@
+#set $sun_altitude_raw = $almanac.sun.alt
+#if $sun_altitude_raw is None
+    #set $sun_altitude_raw = -90.0
+#end if
 #set $sun_rise_raw = $almanac.sun.rise.raw
 #set $sun_set_raw = $almanac.sun.set.raw
 #set $sun_transit_raw = $almanac.sun.transit.raw

--- a/skins/Belchertown/index.html.tmpl
+++ b/skins/Belchertown/index.html.tmpl
@@ -358,7 +358,7 @@
                                 </div>
                                 <div class="almanac-diagram"
                                     data-sun-az="#echo '%.3f' % $almanac.sun.az#"
-                                    data-sun-alt="#echo '%.3f' % $almanac.sun.alt#"
+                                    data-sun-alt="#echo '%.3f' % $sun_altitude_raw#"
                                     data-moon-az="#echo '%.3f' % $almanac.moon.az#"
                                     data-moon-alt="#echo '%.3f' % $almanac.moon.alt#"
                                     data-sun-rise-az="$sun_rise_az_attr"

--- a/skins/Belchertown/json/weewx_data.json.tmpl
+++ b/skins/Belchertown/json/weewx_data.json.tmpl
@@ -565,7 +565,7 @@
             "hasExtras": true,
             "sun": {
                 "azimuth": #echo "%.3f" % $almanac.sun.az#,
-                "altitude": #echo "%.3f" % $almanac.sun.alt#,
+                "altitude": #echo "%.3f" % $sun_altitude_raw#,
                 "rise": {
                     "azimuth": #if $sun_rise_az is not None##echo "%.3f" % $sun_rise_az##else#null#end if#,
                     "altitude": #if $sun_rise_alt is not None##echo "%.3f" % $sun_rise_alt##else#null#end if#

--- a/skins/Belchertown/kiosk.html.tmpl
+++ b/skins/Belchertown/kiosk.html.tmpl
@@ -329,7 +329,7 @@
                                 </div>
                                 <div class="almanac-diagram"
                                     data-sun-az="#echo '%.3f' % $almanac.sun.az#"
-                                    data-sun-alt="#echo '%.3f' % $almanac.sun.alt#"
+                                    data-sun-alt="#echo '%.3f' % $sun_altitude_raw#"
                                     data-moon-az="#echo '%.3f' % $almanac.moon.az#"
                                     data-moon-alt="#echo '%.3f' % $almanac.moon.alt#"
                                     data-sun-rise-az="$sun_rise_az_attr"


### PR DESCRIPTION
## Summary
- define the same sun altitude fallback before the almanac diagram data is built
- use that fallback for homepage/kiosk `data-sun-alt` and the JSON diagram payload

## Why
After #136 merged, the reporter still sees `cannot find 'sun_altitude'` from `index.html.tmpl`, `kiosk.html.tmpl`, and `json/weewx_data.json.tmpl`. Those paths still had direct `$almanac.sun.alt` formatting for the diagram data, so they could bypass the normalized fallback.

## Verification
- `git diff --check`