### PR TITLE
Fix invisible wind speed line on windBarb charts

### DIFF
--- a/skins/new-belchertown/js/new-belchertown-charts.js.tmpl
+++ b/skins/new-belchertown/js/new-belchertown-charts.js.tmpl
@@ -1652,6 +1652,7 @@ function showChart(json_file, prepend_renderTo = false) {
                 options.series.push({
                     type: "line",
                     id: "windbarb-windspeed",
+                    gapSize: 0,
                     name: windBarbSeries.name,
                     data: windSpeedLineData,
                     color: windBarbSeries.color,


### PR DESCRIPTION
## The bug

When a chart uses a `[[[windBarb]]]` series, the skin pushes an auto-generated wind speed line series built from `windspeedData`. That line renders invisible: it appears in the legend, `hasGraph` is true, but nothing is drawn.

## Root cause

The pushed series inherits the chart-wide `plotOptions.line.gapSize`, which is set from the chart group's `gapsize` option — sized for raw archive-interval data (e.g. 300 000 ms for 5-minute data). The speed line's points, however, are spaced at the much larger `aggregate_interval` (hourly or more), so Highcharts treats every point-to-point step as a gap. The resulting SVG path contains only `M` (move) commands and zero `L` segments — an invisible line.

This is likely why the wiki's combined example pairs `[[[windBarb]]]` with an explicit `[[[windSpeed]]]` series: the auto line alone never shows.

## Fix

Set `gapSize: 0` on the pushed series only, disabling gap detection for it. Barbs and all other series are unaffected. Verified on a live weewx 5.1 site: day charts now show the speed line alongside hourly barbs, week charts with 3-hourly barbs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)