### PR TITLE
Fix yAxis_tickInterval case in charts.conf.example

### DIFF
--- a/skins/new-belchertown/charts.conf.example
+++ b/skins/new-belchertown/charts.conf.example
@@ -81,7 +81,7 @@ tooltip_date_format = "LLL"
         type = spline
         [[[barometer]]]
             color = "#BECC00"
-            yAxis_tickinterval = 0.01
+            yAxis_tickInterval = 0.01
 
 [day]
     # Chart Timespan Defaults


### PR DESCRIPTION
The chart generator reads this option as `yAxis_tickInterval` (capital I) — see `new-belchertown-charts.js.tmpl`. The shipped example uses lowercase `yAxis_tickinterval` on the homepage barometer chart, which is silently ignored, so anyone copying the example never gets the documented tick interval and has no error to go on.

🤖 Generated with [Claude Code](https://claude.com/claude-code)