### PR TITLE
Keep almanac sun/moon diagram inside its grid column on phones

### DIFF
--- a/skins/new-belchertown/style.css
+++ b/skins/new-belchertown/style.css
@@ -2423,6 +2423,9 @@ p.entry-meta {
   display: block;
   margin: 0 auto;
   overflow: visible;
+  width: 100%;
+  max-width: 180px;
+  height: auto;
 }
 
 .almanac-diagram-track {


### PR DESCRIPTION
## The bug

On narrow phone screens the almanac card's sun/moon path diagram bleeds underneath the sunrise/sunset (and moonrise/moonset) labels on either side of it.

## Root cause

The diagram SVG is emitted with a fixed `width="180"` attribute, while the three-column grid it sits in (`rise-stack | diagram | set-stack`) can compress the middle column below 180px on small viewports. Combined with `overflow: visible` on the SVG, the curve and markers escape the column and overlap the neighbouring stacks.

## Fix

Let the SVG shrink with its column: `width: 100%` capped at the designed `max-width: 180px`, with `height: auto` preserving the viewBox aspect ratio. Desktop rendering is unchanged (the column is ≥180px there, so the cap applies). Verified on a live site at 393px viewport width.

🤖 Generated with [Claude Code](https://claude.com/claude-code)