### PR TITLE
Add per-series yAxis plotLine options for threshold lines

### DIFF
--- a/skins/new-belchertown/js/new-belchertown-charts.js.tmpl
+++ b/skins/new-belchertown/js/new-belchertown-charts.js.tmpl
@@ -1053,6 +1053,24 @@ function showChart(json_file, prepend_renderTo = false) {
                 options.yAxis[this_yAxis].softMin = axisOptionNumber(s, "yAxis_softMin");
                 options.yAxis[this_yAxis].softMax = axisOptionNumber(s, "yAxis_softMax");
 
+                // Optional horizontal threshold line on this series' yAxis
+                // (e.g. a river flood level or a frost line).
+                if (isFiniteNumber(s.yAxis_plotLine_value)) {
+                    options.yAxis[this_yAxis].plotLines = [{
+                        value: parseFloat(s.yAxis_plotLine_value),
+                        color: s.yAxis_plotLine_color || "#dc322f",
+                        dashStyle: "ShortDash",
+                        width: 2,
+                        zIndex: 5,
+                        label: {
+                            text: s.yAxis_plotLine_label || null,
+                            align: "right",
+                            x: -8,
+                            style: { color: s.yAxis_plotLine_color || "#dc322f", fontWeight: "bold" }
+                        }
+                    }];
+                }
+
                 // Set the yAxis tick interval. Mostly used for barometer. 
                 if (isFiniteNumber(s.yAxis_tickInterval) && parseFloat(s.yAxis_tickInterval) > 0) {
                     options.yAxis[this_yAxis].tickInterval = parseFloat(s.yAxis_tickInterval);

--- a/skins/new-belchertown/js/new-belchertown-charts.js.tmpl
+++ b/skins/new-belchertown/js/new-belchertown-charts.js.tmpl
@@ -1056,9 +1056,11 @@ function showChart(json_file, prepend_renderTo = false) {
                 // Optional horizontal threshold line on this series' yAxis
                 // (e.g. a river flood level or a frost line).
                 if (isFiniteNumber(s.yAxis_plotLine_value)) {
-                    options.yAxis[this_yAxis].plotLines = [{
+                    var plotLineColor = s.yAxis_plotLine_color || "#dc322f";
+                    options.yAxis[this_yAxis].plotLines = options.yAxis[this_yAxis].plotLines || [];
+                    options.yAxis[this_yAxis].plotLines.push({
                         value: parseFloat(s.yAxis_plotLine_value),
-                        color: s.yAxis_plotLine_color || "#dc322f",
+                        color: plotLineColor,
                         dashStyle: "ShortDash",
                         width: 2,
                         zIndex: 5,
@@ -1066,9 +1068,9 @@ function showChart(json_file, prepend_renderTo = false) {
                             text: s.yAxis_plotLine_label || null,
                             align: "right",
                             x: -8,
-                            style: { color: s.yAxis_plotLine_color || "#dc322f", fontWeight: "bold" }
+                            style: { color: plotLineColor, fontWeight: "bold" }
                         }
-                    }];
+                    });
                 }
 
                 // Set the yAxis tick interval. Mostly used for barometer. 


### PR DESCRIPTION
## What

New optional series-level options in `charts.conf` that render a dashed horizontal threshold line on the series' yAxis:

```ini
[[[riverLevel]]]
    yAxis_plotLine_value = 1.2
    yAxis_plotLine_label = "Flood Level (1.2m)"
    yAxis_plotLine_color = "#dc322f"
```

Only `yAxis_plotLine_value` is required; the colour defaults to a red dash and the label is omitted when unset.

## Why

Fixed reference thresholds are common in weather charts — river flood levels, frost point on a temperature chart, gale force on a wind chart. Highcharts supports this natively via `yAxis.plotLines`; this exposes it through chart config with no Python changes (unknown series options already pass through the config reader into the chart JSON).

Running in production on a river-level chart — happy to add a commented example to `charts.conf.example` or a wiki entry if you'd take this.

🤖 Generated with [Claude Code](https://claude.com/claude-code)