### PR TITLE
Port skin from Bootstrap 3.4.1 to Bootstrap 5.3.3

### DIFF
--- a/skins/new-belchertown/charts/index.html.tmpl
+++ b/skins/new-belchertown/charts/index.html.tmpl
@@ -57,7 +57,7 @@
                                         <div class="chartpage-title wx-buttons-description">\
                                             <a href="./?chart='+ chartgroup + '">' + chartgroups_titles[chartgroup] + '</a>\
                                         </div>\
-                                        <div class="chartpage-content col-sm-12">'+ page_content + '</div>\
+                                        <div class="chartpage-content col-md-12">'+ page_content + '</div>\
                                         <div class="' + chartgroup + '"></div>\
                                     </div>\
                                 ');
@@ -68,7 +68,7 @@
 
                             // Within each title section add the chart divs with the chart group prepending to avoid conflicts
                             chartgroups_raw[chartgroup].forEach(chartID => {
-                                jQuery("." + chartgroup).append('<div class="col-sm-6"><div id="' + chartgroup + "_" + chartID + '" style="width:100%;height:100%;margin-top:20px;"></div></div>');
+                                jQuery("." + chartgroup).append('<div class="col-md-6"><div id="' + chartgroup + "_" + chartID + '" style="width:100%;height:100%;margin-top:20px;"></div></div>');
                             });
 
                             chartGroupEntries.push({
@@ -105,7 +105,7 @@
                         // Loop through the chart group for this page and add the chart divs to the page
                         try {
                             thisPageCharts.forEach(chartID => {
-                                jQuery(".chart-outer").append('<div class="col-sm-12"><div id="' + chartID + '" style="width:100%;height:100%;margin-top:20px;"></div></div>');
+                                jQuery(".chart-outer").append('<div class="col-md-12"><div id="' + chartID + '" style="width:100%;height:100%;margin-top:20px;"></div></div>');
                             });
 
                             // Set page title
@@ -141,20 +141,20 @@
 
             <!-- Begin row -->
             <div class="row">
-                <div class="col-sm-12 wx-buttons">
+                <div class="col-md-12 wx-buttons">
                     #if $Extras.has_key("chart_page_show_all_button") and $Extras.chart_page_show_all_button == '1'
                     <a href="./?chart=all"><button type="button"
                             class="btn btn-primary wx-btn-year">$charts_page_all_button_label</button></a>
                     #end if
                     $chart_page_buttons
                 </div>
-                <div class="col-sm-12 wx-buttons-description">
+                <div class="col-md-12 wx-buttons-description">
                     <span class='chartpage-title'></span>
                 </div>
             </div>
             <!-- End row -->
 
-            <div class="chartpage-content col-sm-12"></div><!-- JS populated -->
+            <div class="chartpage-content col-md-12"></div><!-- JS populated -->
 
             <div class="chart-outer"></div><!-- JS populated -->
 

--- a/skins/new-belchertown/footer.html.tmpl
+++ b/skins/new-belchertown/footer.html.tmpl
@@ -4,13 +4,13 @@
 <footer class="site-footer">
     <div class="wrap">
         <div class="row">
-            <div class="col-sm-4 footerLeft">
+            <div class="col-md-4 footerLeft">
                 $obs.label.copyright &copy; $current.dateTime.format("%Y") $obs.label.footer_copyright_text
             </div>
-            <div class="col-sm-4 footerCenter">
+            <div class="col-md-4 footerCenter">
                 <strong>$obs.label.footer_disclaimer_text</strong>
             </div>
-            <div class="col-sm-4 footerRight">
+            <div class="col-md-4 footerRight">
                 $obs.label.footer_theme_by <a href="https://github.com/uajqq/weewx-belchertown-new" target="_blank">Pat O'Brien and uajqq</a>
             </div>
         </div>

--- a/skins/new-belchertown/header.html.tmpl
+++ b/skins/new-belchertown/header.html.tmpl
@@ -123,6 +123,7 @@
         <link rel='dns-prefetch' href='//fonts.googleapis.com' />
         <link rel='dns-prefetch' href='//fonts.gstatic.com' />
         <link rel='dns-prefetch' href='//stackpath.bootstrapcdn.com' />
+        <link rel='dns-prefetch' href='//cdn.jsdelivr.net' />
         <link rel='dns-prefetch' href='//cdnjs.cloudflare.com' />
 
         #if $load_core_js
@@ -130,6 +131,7 @@
         #end if
         <link rel='preconnect' href='https://fonts.gstatic.com' crossorigin>
         <link rel='preconnect' href='https://stackpath.bootstrapcdn.com' crossorigin>
+        <link rel='preconnect' href='https://cdn.jsdelivr.net' crossorigin>
         <link rel='preconnect' href='https://cdnjs.cloudflare.com' crossorigin>
 
         <link rel='preload' href='//fonts.googleapis.com/css?family=Roboto%3A300%2C400%2C700&#038;display=swap&#038;ver=1.0' as='style' onload="this.onload=null;this.rel='stylesheet'">
@@ -140,9 +142,9 @@
             <link rel='stylesheet' href='//stackpath.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css' type='text/css' media='all' />
             <link rel='stylesheet' href='//cdnjs.cloudflare.com/ajax/libs/weather-icons/2.0.9/css/weather-icons.min.css?ver=4.7.4' type='text/css' media='all' />
         </noscript>
-        <link rel='preload' href='//stackpath.bootstrapcdn.com/bootstrap/3.4.1/css/bootstrap.min.css' as='style' onload="this.onload=null;this.rel='stylesheet'">
+        <link rel='preload' href='//cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css' as='style' onload="this.onload=null;this.rel='stylesheet'">
         <noscript>
-            <link rel='stylesheet' href='//stackpath.bootstrapcdn.com/bootstrap/3.4.1/css/bootstrap.min.css' type='text/css' media='all' />
+            <link rel='stylesheet' href='//cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css' type='text/css' media='all' />
         </noscript>
         <link rel='stylesheet' href='$relative_url/style${asset_suffix}.css?ver=$asset_version' type='text/css' media='all' id="belchertownStyle" />
         #if $bodyTheme == "dark"
@@ -243,7 +245,7 @@
         </script>
         #end if
         #if $load_bootstrap_js
-        <script defer type='text/javascript' src='//stackpath.bootstrapcdn.com/bootstrap/3.4.1/js/bootstrap.min.js'></script>
+        <script defer type='text/javascript' src='//cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/js/bootstrap.bundle.min.js'></script>
         #end if
         <script defer type='text/javascript' src='$relative_url/js/new-belchertown-utils${asset_suffix}.js?ver=$asset_version'></script>
         #if $load_core_js

--- a/skins/new-belchertown/index.html.tmpl
+++ b/skins/new-belchertown/index.html.tmpl
@@ -248,7 +248,7 @@
                         <section class="homepage-card homepage-card--temperature">
                             <div class="homepage-card-body homepage-temperature-content">
                                 <div class="row temp-observation">
-                                    <div class="col-sm-6 current_obs_top">
+                                    <div class="col-md-6 current_obs_top">
                                         #if $Extras.has_key("forecast_enabled") and $Extras.forecast_enabled == '1'
                                             #set $homepage_current_icon = "unknown.png"
                                             #if $current_obs_icon != ""
@@ -257,7 +257,7 @@
                                             <img id="wxicon" src="$relative_url/images/$homepage_current_icon" alt="$obs.label.current_conditions" width="128" height="101" loading="eager" decoding="async" fetchpriority="high">
                                         #end if
                                     </div>
-                                    <div class="col-sm-6 current_temp">
+                                    <div class="col-md-6 current_temp">
                                         <div class="outtemp_outer">
                                             <span class="outtemp">$current.outTemp.formatted</span>
                                             <sup class="outtempunitlabelsuper">$unit.label.outTemp</sup>
@@ -265,7 +265,7 @@
                                     </div>
                                 </div>
                                 <div class="row homepage-temperature-details">
-                                    <div class="col-sm-6 current-obs-container">
+                                    <div class="col-md-6 current-obs-container">
                                         <div class="current-obs-text">
                                             $current_obs_summary
                                         </div>
@@ -278,7 +278,7 @@
                                         </div>
                                         #end if
                                     </div>
-                                    <div class="col-sm-6 homepage-temperature-sidebar">
+                                    <div class="col-md-6 homepage-temperature-sidebar">
                                         #if $current.appTemp.has_data
                                         <div class="feelslike">$obs.label.feels_like $current.appTemp</div><!-- AJAX -->
                                         #end if
@@ -319,8 +319,8 @@
                         <section class="homepage-card homepage-card--wind#if $Extras.has_key('wind_compass_marker') and str($Extras.wind_compass_marker).strip() == 'windbarb'# homepage-card--windbarb#end if#">
                             <div class="homepage-card-body">
                                 <div class="windrow">
-                                    <div class="col-sm-12 current_wind">
-                                        <div class="col-sm-6">
+                                    <div class="col-md-12 current_wind">
+                                        <div class="col-md-6">
                                             <div class="compass">
                                                 <div class="direction">
                                                     <span class="curwinddir">
@@ -341,7 +341,7 @@
                                                 <div class="arrow$wind_compass_marker_class"$wind_compass_marker_style_attr></div>
                                             </div>
                                         </div>
-                                        <div class="col-sm-6 windspeedtable">
+                                        <div class="col-md-6 windspeedtable">
                                             <table class="wind-table">
                                                 <tbody>
                                                     <tr>
@@ -407,7 +407,7 @@
                                     </div>
                                     #if $Extras.has_key("almanac_extras") and $Extras.almanac_extras == '1' and $almanac.hasExtras
                                     <div class="almanac-details-link almanac-details-link--inline">
-                                        <a href="#almanac-modal" data-toggle="modal" data-target="#almanac-modal">$obs.label.almanac_more_details</a>
+                                        <a href="#almanac-modal" data-bs-toggle="modal" data-bs-target="#almanac-modal">$obs.label.almanac_more_details</a>
                                     </div>
                                     #end if
                                 </div>
@@ -416,16 +416,14 @@
                                         <div class="modal-dialog modal-lg" role="document">
                                             <div class="modal-content">
                                                 <div class="modal-header">
-                                                    <button type="button" class="close" data-dismiss="modal" aria-label="$obs.label.close">
-                                                        <span aria-hidden="true">&times;</span>
-                                                    </button>
                                                     <h4 class="modal-title" id="almanac-modal-title">$obs.label.almanac_modal_title</h4>
+                                                    <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="$obs.label.close"></button>
                                                 </div>
                                                 <div class="almanac-extras-modal-body modal-body">
                                                     #include "celestial.inc"
                                                 </div><!-- AJAX -->
                                                 <div class="modal-footer">
-                                                    <button type="button" class="btn btn-primary" data-dismiss="modal">$obs.label.close</button>
+                                                    <button type="button" class="btn btn-primary" data-bs-dismiss="modal">$obs.label.close</button>
                                                 </div>
                                             </div>
                                         </div>
@@ -477,16 +475,16 @@
                 <div class="row forecastrow">
                     #if $Extras.has_key("forecast_interval_hours") and $Extras.forecast_interval_hours != '0'
                     <div id="1hour-selected-forecast" style="display: none;">
-                        <div class="col-lg-12 row onehr_forecasts row-no-padding"></div><!-- JS -->
+                        <div class="col-xl-12 row onehr_forecasts row-no-padding"></div><!-- JS -->
                     </div>
                     #end if
 
                     <div id="3hour-selected-forecast" style="display: none;">
-                        <div class="col-lg-12 row threehr_forecasts row-no-padding"></div><!-- JS -->
+                        <div class="col-xl-12 row threehr_forecasts row-no-padding"></div><!-- JS -->
                     </div>
 
                     <div id="24hour-selected-forecast" style="display: none;">
-                        <div class="col-lg-12 row day_forecasts row-no-padding"></div><!-- JS -->
+                        <div class="col-xl-12 row day_forecasts row-no-padding"></div><!-- JS -->
                     </div>
                 </div>
             </section>
@@ -520,9 +518,9 @@
                     </div>
                     <div class="homepage-card-body">
                         <div class="row">
-                            <div class="col-sm-6 stn-quick-stats">
+                            <div class="col-md-6 stn-quick-stats">
                                 <div class="stats-title">
-                                    <label class="sr-only" for="snapshot-day-select">$obs.label.weather_snapshots $obs.label.snapshot_period_today</label>
+                                    <label class="visually-hidden" for="snapshot-day-select">$obs.label.weather_snapshots $obs.label.snapshot_period_today</label>
                                     <select id="snapshot-day-select" class="snapshot-period-select">
                                         <option value="day">$obs.label.snapshot_period_today</option>
                                         <option value="yesterday">$obs.label.snapshot_period_yesterday</option>
@@ -557,9 +555,9 @@
                                 </div>
                             </div>
 
-                            <div class="col-sm-6 stn-quick-stats homepage-snapshot-column homepage-snapshot-column--secondary">
+                            <div class="col-md-6 stn-quick-stats homepage-snapshot-column homepage-snapshot-column--secondary">
                                 <div class="stats-title">
-                                    <label class="sr-only" for="snapshot-month-select">$obs.label.weather_snapshots $obs.label.snapshot_period_month</label>
+                                    <label class="visually-hidden" for="snapshot-month-select">$obs.label.weather_snapshots $obs.label.snapshot_period_month</label>
                                     <select id="snapshot-month-select" class="snapshot-period-select">
                                         <option value="month">$obs.label.snapshot_period_month</option>
                                         <option value="year">$obs.label.snapshot_period_ytd</option>
@@ -615,10 +613,10 @@
                         <div class="earthquake-subcard earthquake-subcard--stats">
                             <a class="earthquake-info-link" href="$earthquake_url" target="_blank">
                                 <div class="row earthquake-info">
-                                    <div class="col-sm-6 earthquake-stat earthquake-stat--magnitude">
+                                    <div class="col-md-6 earthquake-stat earthquake-stat--magnitude">
                                         <i class="wi wi-earthquake" aria-hidden="true"></i><span class="earthquake-stat-label">$obs.label.earthquake_magnitude</span> <span class="magnitude">$earthquake_magnitude</span>
                                     </div>
-                                    <div class="col-sm-6 earthquake-distance-outer border-left earthquake-stat earthquake-stat--distance">
+                                    <div class="col-md-6 earthquake-distance-outer border-left earthquake-stat earthquake-stat--distance">
                                         <span class="earthquake-distance">$earthquake_distance_away $earthquake_distance_label $earthquake_bearing</span>
                                     </div>
                                 </div>

--- a/skins/new-belchertown/index_radar.inc.example
+++ b/skins/new-belchertown/index_radar.inc.example
@@ -25,6 +25,23 @@ See other example at https://github.com/poblabs/weewx-belchertown/issues/703 -->
 </div>
 
 <style>
+/* Bootstrap 5 only styles .nav-link inside .nav-tabs; the radar tabs use a
+   custom JS switcher with bare links, so restore the BS3-style tab look */
+.tabs-menu > li { margin-bottom: -1px; }
+.tabs-menu > li > a {
+    display: block;
+    padding: 8px 12px;
+    border: 1px solid transparent;
+    border-radius: 8px 8px 0 0;
+    text-decoration: none;
+}
+.tabs-menu > li > a:hover { background-color: rgba(128, 128, 128, 0.12); }
+.tabs-menu > li.active > a {
+    border-color: #ddd #ddd transparent;
+    cursor: default;
+}
+.dark .tabs-menu > li.active > a { border-color: #555 #555 transparent; }
+
 .dark .tabs-menu > li > a {
     padding: 0px 5px;
 }

--- a/skins/new-belchertown/js/new-belchertown-forecast.js.tmpl
+++ b/skins/new-belchertown/js/new-belchertown-forecast.js.tmpl
@@ -307,12 +307,12 @@ function forecast_ensure_observation_modal() {
     modal += "<div class='modal-dialog modal-sm' role='document'>";
     modal += "<div class='modal-content'>";
     modal += "<div class='modal-header'>";
-    modal += "<button type='button' class='close' data-dismiss='modal' aria-label='" + forecast_escape_html(forecast_label_text("$obs.label.close")) + "'><span aria-hidden='true'>&times;</span></button>";
     modal += "<h4 class='modal-title' id='observation-source-modal-title'>" + forecast_escape_html(forecast_label_text("$obs.label.observation_source")) + "</h4>";
+    modal += "<button type='button' class='btn-close' data-bs-dismiss='modal' aria-label='" + forecast_escape_html(forecast_label_text("$obs.label.close")) + "'></button>";
     modal += "</div>";
     modal += "<div class='modal-body observation-source-modal-body'></div>";
     modal += "<div class='modal-footer'>";
-    modal += "<button type='button' class='btn btn-primary' data-dismiss='modal'>" + forecast_escape_html(forecast_label_text("$obs.label.close")) + "</button>";
+    modal += "<button type='button' class='btn btn-primary' data-bs-dismiss='modal'>" + forecast_escape_html(forecast_label_text("$obs.label.close")) + "</button>";
     modal += "</div>";
     modal += "</div>";
     modal += "</div>";
@@ -531,14 +531,14 @@ function forecast_alert_modal_html(forecastAlertId, forecastAlertTitleId, alertD
     modal += "<div class='modal-dialog' role='document'>";
     modal += "<div class='modal-content'>";
     modal += "<div class='modal-header'>";
-    modal += "<button type='button' class='close' data-dismiss='modal' aria-label='" + forecast_escape_html(forecast_label_text("$obs.label.close")) + "'><span aria-hidden='true'>&times;</span></button>";
     modal += "<h4 class='modal-title' id='" + forecastAlertTitleId + "'>" + forecast_escape_html(alertData["title"]) + "</h4>";
+    modal += "<button type='button' class='btn-close' data-bs-dismiss='modal' aria-label='" + forecast_escape_html(forecast_label_text("$obs.label.close")) + "'></button>";
     modal += "</div>";
     modal += "<div class='modal-body'>";
     modal += alertData["body"];
     modal += "</div>";
     modal += "<div class='modal-footer'>";
-    modal += "<button type='button' class='btn btn-primary' data-dismiss='modal'>" + forecast_escape_html(forecast_label_text("$obs.label.close")) + "</button>";
+    modal += "<button type='button' class='btn btn-primary' data-bs-dismiss='modal'>" + forecast_escape_html(forecast_label_text("$obs.label.close")) + "</button>";
     modal += "</div>";
     modal += "</div>";
     modal += "</div>";
@@ -628,7 +628,7 @@ function show_forcast_alert(data) {
             }
 
             currentAlertIds[forecastAlertId] = true;
-            alert_link = "<i class='fa fa-exclamation-triangle' aria-hidden='true'></i> <a href='#" + forecastAlertId + "' data-toggle='modal' data-target='#" + forecastAlertId + "'>" + forecast_escape_html(alertLinkText) + "</a><br>";
+            alert_link = "<i class='fa fa-exclamation-triangle' aria-hidden='true'></i> <a href='#" + forecastAlertId + "' data-bs-toggle='modal' data-bs-target='#" + forecastAlertId + "'>" + forecast_escape_html(alertLinkText) + "</a><br>";
             alertContainer.append(alert_link);
 
             var forecast_alert_modal = forecast_alert_modal_by_id(forecastAlertId);

--- a/skins/new-belchertown/js/new-belchertown-mqtt.js.tmpl
+++ b/skins/new-belchertown/js/new-belchertown-mqtt.js.tmpl
@@ -117,8 +117,8 @@ function mqtt_ensure_status_modal() {
     modal += "<div class='modal-dialog mqtt-status-modal-dialog' role='document'>";
     modal += "<div class='modal-content'>";
     modal += "<div class='modal-header'>";
-    modal += "<button type='button' class='close mqtt-status-modal-dismiss' data-dismiss='modal' aria-label='" + belchertown_label_html("$obs.label.close") + "'><span aria-hidden='true'>&times;</span></button>";
     modal += "<h4 class='modal-title' id='mqtt-status-modal-title'>" + belchertown_label_html("$obs.label.mqtt_live_update_details") + "</h4>";
+    modal += "<button type='button' class='btn-close mqtt-status-modal-dismiss' data-bs-dismiss='modal' aria-label='" + belchertown_label_html("$obs.label.close") + "'></button>";
     modal += "</div>";
     modal += "<div class='modal-body'>";
     modal += "<dl class='mqtt-status-detail-list'>";
@@ -132,7 +132,7 @@ function mqtt_ensure_status_modal() {
     modal += "</div>";
     modal += "</div>";
     modal += "<div class='modal-footer'>";
-    modal += "<button type='button' class='btn btn-primary mqtt-status-modal-dismiss' data-dismiss='modal'>" + belchertown_label_html("$obs.label.close") + "</button>";
+    modal += "<button type='button' class='btn btn-primary mqtt-status-modal-dismiss' data-bs-dismiss='modal'>" + belchertown_label_html("$obs.label.close") + "</button>";
     modal += "</div>";
     modal += "</div>";
     modal += "</div>";

--- a/skins/new-belchertown/js/new-belchertown.js.tmpl
+++ b/skins/new-belchertown/js/new-belchertown.js.tmpl
@@ -741,7 +741,7 @@ jQuery(document).ready(function() {
 
     // Bootstrap hover tooltips
     if (jQuery.fn.tooltip) {
-        jQuery('[data-toggle="tooltip"]').tooltip()
+        jQuery('[data-bs-toggle="tooltip"]').tooltip()
     }
 
     // Fail-open for pages generated with deferred iframe markup.

--- a/skins/new-belchertown/kiosk.html.tmpl
+++ b/skins/new-belchertown/kiosk.html.tmpl
@@ -199,7 +199,7 @@
                         <section class="homepage-card homepage-card--temperature">
                             <div class="homepage-card-body homepage-temperature-content">
                                 <div class="row temp-observation">
-                                    <div class="col-sm-6 current_obs_top">
+                                    <div class="col-md-6 current_obs_top">
                                         #if $Extras.has_key("forecast_enabled") and $Extras.forecast_enabled == '1'
                                             #set $kiosk_current_icon = "unknown.png"
                                             #if $current_obs_icon != ""
@@ -208,12 +208,12 @@
                                             <img id="wxicon" src="$relative_url/images/$kiosk_current_icon" alt="$obs.label.current_conditions" width="128" height="101" loading="eager" decoding="async" fetchpriority="high">
                                         #end if
                                     </div>
-                                    <div class="col-sm-6 current_temp">
+                                    <div class="col-md-6 current_temp">
                                         <div class="outtemp_outer"><span class="outtemp">$current.outTemp.formatted</span><sup class="outtempunitlabelsuper">$unit.label.outTemp</sup></div><!-- AJAX -->
                                     </div>
                                 </div>
                                 <div class="row homepage-temperature-details">
-                                    <div class="col-sm-6 current-obs-container">
+                                    <div class="col-md-6 current-obs-container">
                                         <div class="current-obs-text">
                                             $current_obs_summary
                                         </div>
@@ -226,7 +226,7 @@
                                         </div>
                                         #end if
                                     </div>
-                                    <div class="col-sm-6 homepage-temperature-sidebar">
+                                    <div class="col-md-6 homepage-temperature-sidebar">
                                         #if $current.appTemp.has_data
                                         <div class="feelslike">$obs.label.feels_like $current.appTemp</div><!-- AJAX -->
                                         #end if
@@ -267,8 +267,8 @@
                         <section class="homepage-card homepage-card--wind#if $Extras.has_key('wind_compass_marker') and str($Extras.wind_compass_marker).strip() == 'windbarb'# homepage-card--windbarb#end if#">
                             <div class="homepage-card-body">
                                 <div class="row windrow">
-                                    <div class="col-sm-12 current_wind">
-                                        <div class="col-sm-6">
+                                    <div class="col-md-12 current_wind">
+                                        <div class="col-md-6">
                                             <div class="compass">
                                                 <div class="direction">
                                                     <span class="curwinddir">
@@ -289,7 +289,7 @@
                                                 <div class="arrow$wind_compass_marker_class"$wind_compass_marker_style_attr></div>
                                             </div>
                                         </div>
-                                        <div class="col-sm-6 windspeedtable">
+                                        <div class="col-md-6 windspeedtable">
                                             <table class="wind-table">
                                                 <tbody>
                                                     <tr>
@@ -355,7 +355,7 @@
                                     </div>
                                     #if $Extras.has_key("almanac_extras") and $Extras.almanac_extras == '1' and $almanac.hasExtras
                                     <div class="almanac-details-link almanac-details-link--inline">
-                                        <a href="#almanac-modal" data-toggle="modal" data-target="#almanac-modal">$obs.label.almanac_more_details</a>
+                                        <a href="#almanac-modal" data-bs-toggle="modal" data-bs-target="#almanac-modal">$obs.label.almanac_more_details</a>
                                     </div>
                                     #end if
                                 </div>
@@ -364,16 +364,14 @@
                                         <div class="modal-dialog modal-lg" role="document">
                                             <div class="modal-content">
                                                 <div class="modal-header">
-                                                    <button type="button" class="close" data-dismiss="modal" aria-label="$obs.label.close">
-                                                        <span aria-hidden="true">&times;</span>
-                                                    </button>
                                                     <h4 class="modal-title" id="almanac-modal-title">$obs.label.almanac_modal_title</h4>
+                                                    <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="$obs.label.close"></button>
                                                 </div>
                                                 <div class="almanac-extras-modal-body modal-body">
                                                     #include "celestial.inc"
                                                 </div><!-- AJAX -->
                                                 <div class="modal-footer">
-                                                    <button type="button" class="btn btn-primary" data-dismiss="modal">$obs.label.close</button>
+                                                    <button type="button" class="btn btn-primary" data-bs-dismiss="modal">$obs.label.close</button>
                                                 </div>
                                             </div>
                                         </div>
@@ -411,13 +409,13 @@
             <section class="homepage-card homepage-card--forecast">
             <div class="row forecastrow">
                 <!-- Forecast -->
-                <div class="col-lg-8 forecast-title">
+                <div class="col-xl-8 forecast-title">
                     #if $forecast_header_prefix
                     <span class="forecast-header-label">#echo $forecast_header_prefix#</span>
                     #end if
                     <span class="forecast-subtitle"></span><!-- moment.js --> <span class="forecast-source"></span>
                 </div>
-                <div class="col-lg-4 forecast-menu">
+                <div class="col-xl-4 forecast-menu">
                     $obs.label.forecast_interval_caption <div class="forecast-button" onclick="forecast_select(1);" id="button1">1</div>
                     <div class="forecast-button" onclick="forecast_select(3);" id="button3">3</div>
                     <div class="forecast-button" onclick="forecast_select(24);" id="button24">24</div>
@@ -426,18 +424,18 @@
                 #if $Extras.has_key("forecast_interval_hours_kiosk") and $Extras.forecast_interval_hours_kiosk != '0'
                 <div id="1hour-selected-forecast" style="display: none;">
                     <!-- 1hour Forecast -->
-                    <div class="col-lg-12 row onehr_forecasts row-no-padding"></div><!-- JS -->
+                    <div class="col-xl-12 row onehr_forecasts row-no-padding"></div><!-- JS -->
                 </div>
                 #end if
 
                 <div id="3hour-selected-forecast" style="display: none;">
                     <!-- 3hour-Forecast -->
-                    <div class="col-lg-12 row threehr_forecasts row-no-padding"></div><!-- JS -->
+                    <div class="col-xl-12 row threehr_forecasts row-no-padding"></div><!-- JS -->
                 </div>
 
                 <div id="24hour-selected-forecast" style="display: none;">
                     <!-- 24hour-Forecast -->
-                    <div class="col-lg-12 row day_forecasts row-no-padding"></div><!-- JS -->
+                    <div class="col-xl-12 row day_forecasts row-no-padding"></div><!-- JS -->
                 </div>
             </div>
             </section>

--- a/skins/new-belchertown/page-header.inc
+++ b/skins/new-belchertown/page-header.inc
@@ -1,7 +1,7 @@
 #encoding UTF-8
 <div class="wx-stn-info-container">
     <div class="row">
-        <div class="col-sm-1 wx-stn-info-current-obs">
+        <div class="col-md-1 wx-stn-info-current-obs">
             <span class="obs-header-icon">
                 #if $Extras.has_key("forecast_enabled") and $Extras.forecast_enabled == '1' and $current_obs_icon != ""
                 <img id="wxicon" src="${relative_url}/images/${current_obs_icon}" alt="$obs.label.current_conditions" width="128" height="101" loading="eager" decoding="async" fetchpriority="high">
@@ -9,7 +9,7 @@
             </span>
             <span class="obs-header-outtemp">$current.outTemp</span>
         </div>
-        <div class="col-sm-5">
+        <div class="col-md-5">
             <div class="wx-stn-name">
 		#if $page == "charts"
         <h1>$charts_page_header_label</h1>
@@ -22,12 +22,12 @@
 		#end if
             </div>
         </div>
-        <div class="col-sm-5" style="float:right;">
+        <div class="col-md-5" style="float:right;">
             <div class="wx-stn-info">
                 $obs.label.powered_by
             </div>
             #if $social_html != ""
-            <div class="col-sm-10 wx-stn-info-social" style="float:right;">
+            <div class="col-md-10 wx-stn-info-social" style="float:right;">
                 $social_html
             </div>
             #end if

--- a/skins/new-belchertown/pi/index.html.tmpl
+++ b/skins/new-belchertown/pi/index.html.tmpl
@@ -94,7 +94,7 @@
                     <div class="row">
                         <!-- Temperature -->
 
-                        <div class="col-xs-6 temp-observation">
+                        <div class="col-6 temp-observation">
                             <div class="obs-group">
                                 <img id="wxicon" src="$relative_url/images/$current_obs_icon" alt="$obs.label.current_conditions" width="128" height="101" loading="eager" decoding="async" fetchpriority="high"><!-- AJAX -->
                                 <div class="outtemp_outer"><span class="outtemp">$current.outTemp.formatted</span><sup
@@ -169,7 +169,7 @@
 
                         </div>
 
-                        <div class="col-xs-6 wind_col">
+                        <div class="col-6 wind_col">
                             <div class="wind_data">
                                 <div class="compass">
                                     <div class="direction">
@@ -225,12 +225,12 @@
                                     <tr>
                                         <td colspan="2">
                                             <div class="row small-almanac">
-                                                <div class="col-sm-5 sun">
+                                                <div class="col-md-5 sun">
                                                     <span class="sunrise-value">$almanac.sunrise.format("%-I:%M%p")</span><span class="sunrise-set-image sunrise-set-image--rise"><img src="../images/sunrise.png" alt="" width="20" height="10" loading="lazy" decoding="async"></span><!-- AJAX -->
                                                     &nbsp;
                                                     <span class="sunrise-set-image"><img src="../images/sunset.png" alt="" width="20" height="10" loading="lazy" decoding="async"></span><span class="sunset-value">$almanac.sunset.format("%-I:%M%p")</span><!-- AJAX -->
                                                 </div>
-                                                <div class="col-sm-7 moon">
+                                                <div class="col-md-7 moon">
                                                     <div class="moon-container">
                                                         <span class="moon-icon">
                                                             #if $almanac.moon_index == 0

--- a/skins/new-belchertown/reports/index.html.tmpl
+++ b/skins/new-belchertown/reports/index.html.tmpl
@@ -66,7 +66,7 @@
             <div class="noaa_reports">
                 <H1>$obs.label.reports_title</H1>
                 <div class="row">
-                    <div class="col-sm-12 wx-year-row">
+                    <div class="col-md-12 wx-year-row">
                         $noaa_header_html
                     </div>
                 </div>

--- a/skins/new-belchertown/style.css
+++ b/skins/new-belchertown/style.css
@@ -1331,11 +1331,11 @@ p.entry-meta {
     display: none;
   }
 
-  .wx-stn-info-container .col-sm-5 {
+  .wx-stn-info-container .col-md-5 {
     width: 75%;
   }
 
-  .wx-stn-info-container .col-sm-1 {
+  .wx-stn-info-container .col-md-1 {
     width: 10%;
   }
 
@@ -1387,7 +1387,7 @@ p.entry-meta {
     clear: both;
   }
 
-  .eq-stats-row .col-sm-9 {
+  .eq-stats-row .col-md-9 {
     width: 100%;
   }
 
@@ -4868,17 +4868,17 @@ span.highcharts-title {
 }
 
 .charts .chart-outer > [class*="col-"] > div[id],
-.charts .chart-outer-all > .row .col-sm-6 {
+.charts .chart-outer-all > .row .col-md-6 {
   margin-top: 0 !important;
 }
 
-.charts .chart-outer-all > .row .col-sm-6 {
+.charts .chart-outer-all > .row .col-md-6 {
   width: 100%;
   float: none;
   padding: 0;
 }
 
-.charts .chart-outer-all > .row .col-sm-6 + .col-sm-6 {
+.charts .chart-outer-all > .row .col-md-6 + .col-md-6 {
   margin-top: 20px;
 }
 
@@ -4926,10 +4926,10 @@ span.highcharts-title {
   padding: 0;
 }
 
-.charts .wx-stn-info-container > .row > div.col-sm-5:not([style]),
-.records .wx-stn-info-container > .row > div.col-sm-5:not([style]),
-.about .wx-stn-info-container > .row > div.col-sm-5:not([style]),
-.reports .wx-stn-info-container > .row > div.col-sm-5:not([style]) {
+.charts .wx-stn-info-container > .row > div.col-md-5:not([style]),
+.records .wx-stn-info-container > .row > div.col-md-5:not([style]),
+.about .wx-stn-info-container > .row > div.col-md-5:not([style]),
+.reports .wx-stn-info-container > .row > div.col-md-5:not([style]) {
   order: 2;
   flex: 1 1 auto;
   min-width: 0;
@@ -4984,10 +4984,10 @@ span.highcharts-title {
   line-height: 1.15;
 }
 
-.charts .wx-stn-info-container > .row > div.col-sm-5[style],
-.records .wx-stn-info-container > .row > div.col-sm-5[style],
-.about .wx-stn-info-container > .row > div.col-sm-5[style],
-.reports .wx-stn-info-container > .row > div.col-sm-5[style] {
+.charts .wx-stn-info-container > .row > div.col-md-5[style],
+.records .wx-stn-info-container > .row > div.col-md-5[style],
+.about .wx-stn-info-container > .row > div.col-md-5[style],
+.reports .wx-stn-info-container > .row > div.col-md-5[style] {
   order: 3;
   margin-left: auto;
   display: flex;
@@ -5035,10 +5035,10 @@ span.highcharts-title {
   margin-right: 0;
 }
 
-.charts .wx-stn-info-container>.row>div.col-sm-5[style],
-.records .wx-stn-info-container>.row>div.col-sm-5[style],
-.about .wx-stn-info-container>.row>div.col-sm-5[style],
-.reports .wx-stn-info-container>.row>div.col-sm-5[style],
+.charts .wx-stn-info-container>.row>div.col-md-5[style],
+.records .wx-stn-info-container>.row>div.col-md-5[style],
+.about .wx-stn-info-container>.row>div.col-md-5[style],
+.reports .wx-stn-info-container>.row>div.col-md-5[style],
 .charts .wx-stn-info-social[style],
 .records .wx-stn-info-social[style],
 .about .wx-stn-info-social[style],
@@ -5049,10 +5049,10 @@ span.highcharts-title {
   text-align: center;
 }
 
-.charts .wx-stn-info-container > .row > div.col-sm-5[style],
-.records .wx-stn-info-container > .row > div.col-sm-5[style],
-.about .wx-stn-info-container > .row > div.col-sm-5[style],
-.reports .wx-stn-info-container > .row > div.col-sm-5[style] {
+.charts .wx-stn-info-container > .row > div.col-md-5[style],
+.records .wx-stn-info-container > .row > div.col-md-5[style],
+.about .wx-stn-info-container > .row > div.col-md-5[style],
+.reports .wx-stn-info-container > .row > div.col-md-5[style] {
   flex: 0 1 41.66666667%;
   min-width: 0;
   margin-right: 0;
@@ -5578,10 +5578,10 @@ span.highcharts-title {
     gap: 16px;
   }
 
-  .charts .wx-stn-info-container > .row > div.col-sm-5[style],
-  .records .wx-stn-info-container > .row > div.col-sm-5[style],
-  .about .wx-stn-info-container > .row > div.col-sm-5[style],
-  .reports .wx-stn-info-container > .row > div.col-sm-5[style] {
+  .charts .wx-stn-info-container > .row > div.col-md-5[style],
+  .records .wx-stn-info-container > .row > div.col-md-5[style],
+  .about .wx-stn-info-container > .row > div.col-md-5[style],
+  .reports .wx-stn-info-container > .row > div.col-md-5[style] {
     align-items: center;
     margin-left: 0;
     margin-right: 0;
@@ -5711,7 +5711,7 @@ span.highcharts-title {
   word-wrap: normal;
 }
 
-/* .col-sm-1-5 { */
+/* .col-md-1-5 { */
 .forecast-day {
   position: relative;
   min-height: 225px;
@@ -6083,7 +6083,7 @@ body.pi::-webkit-scrollbar {
   margin-bottom: 0px;
 }
 
-.pi .col-xs-6 {
+.pi .col-6 {
   padding-left: 10px !important;
   padding-right: 10px !important;
 }
@@ -6254,7 +6254,7 @@ body.pi::-webkit-scrollbar {
   text-align: center;
 }
 
-.pi .forecastrow .col-lg-12 {
+.pi .forecastrow .col-xl-12 {
   padding: 0;
 }
 
@@ -6332,3 +6332,16 @@ body.pi::-webkit-scrollbar {
     animation: none;
   }
 }
+
+/* ----- Bootstrap 5 compatibility shims for the dark stylesheet ----- */
+/* Bootstrap 5 .btn-close ships as a black X; invert it on dark modal headers */
+.dark .btn-close {
+  filter: invert(1) grayscale(100%) brightness(200%);
+}
+/* The dark stylesheet's embedded Bootstrap 3 clone keys visibility on BS3's
+   .in class; Bootstrap 5 toggles .show instead, leaving modals/backdrops stuck
+   at opacity 0 in dark mode. Restore the .show states at higher specificity. */
+.dark .fade.show { opacity: 1; }
+.dark .modal.fade.show .modal-dialog { transform: none; }
+.dark .modal-backdrop.fade.show { opacity: 0.7; }
+.dark .tooltip.fade.show { opacity: 0.9; }


### PR DESCRIPTION
## What

Moves the skin from Bootstrap 3.4.1 to 5.3.3 (jsdelivr CDN, bundle JS build). First of a four-PR series we discussed — followed by native dark mode (replacing the dark stylesheet), an offcanvas mobile menu, and MQTT connection toasts. Each builds on the previous one.

The changes fall into three groups:

1. **Mechanical renames** across templates/includes/JS/CSS: `col-xs-N` → `col-N`, `col-sm-N` → `col-md-N`, `col-lg-N` → `col-xl-N` (preserves each rule's effective breakpoint), `data-toggle/-target/-dismiss` → `data-bs-*`, `sr-only` → `visually-hidden`, `btn-default` → `btn-secondary`.
2. **CDN swap** in header.html.tmpl, plus the JS becomes `bootstrap.bundle.min.js` (Popper included). jQuery stays — BS5 doesn't need it, but the skin's own JS uses it heavily, and BS5 auto-registers its jQuery plugin interface so existing `.modal()`/`.tooltip()` calls keep working.
3. **Hand conversions**: the five modal headers (almanac in index + kiosk, observation-source + forecast-alert in forecast JS, MQTT status) move to `.btn-close` with title-before-button; index_radar.inc.example gets a small style block because BS5 only styles `.nav-link` inside `.nav-tabs` and the radar tabs use bare links; style.css gets two small shims so the existing dark stylesheet (whose embedded BS3 clone keys modal visibility on `.in`) keeps working — both shims are deleted by the follow-up dark-mode PR.

## Migration notes for users

Customised copies of the `.inc` examples, hook includes or `custom.css` may contain BS3 class names. The renames above are the complete map; a site keeps working if these are applied to custom files. Happy to add this to the wiki.

## Testing

Deployed against a live weewx 5.1 station with a stock config: every page (home, charts, records, reports, about, kiosk, pi) in light and dark, desktop + mobile, with `minify = 0` and `= 1`; all five modals open/close in both themes; radar tabs switch; earthquake card, Open-Meteo forecast and snapshot dropdowns render correctly. Also been running the same conversion on a customised production site for a day. Screenshots available on request.

🤖 Generated with [Claude Code](https://claude.com/claude-code)