### PR TITLE
Update jQuery from 3.3.1 to 3.7.1

### DIFF
--- a/skins/new-belchertown/header.html.tmpl
+++ b/skins/new-belchertown/header.html.tmpl
@@ -170,7 +170,7 @@
         <script type='text/javascript' src='//cdnjs.cloudflare.com/ajax/libs/html5shiv/3.7.3/html5shiv.js'></script>
         <![endif]-->
         #if $load_core_js
-        <script defer type='text/javascript' src="//ajax.googleapis.com/ajax/libs/jquery/3.3.1/jquery.min.js"></script>
+        <script defer type='text/javascript' src="//ajax.googleapis.com/ajax/libs/jquery/3.7.1/jquery.min.js"></script>
         <script defer type='text/javascript' src="//cdnjs.cloudflare.com/ajax/libs/moment.js/2.24.0/moment-with-locales.min.js"></script>
         #if $moment_js_tz and str($moment_js_tz).strip() != ""
         <script defer type='text/javascript' src="https://cdnjs.cloudflare.com/ajax/libs/moment-timezone/0.5.33/moment-timezone-with-data.min.js"></script>


### PR DESCRIPTION
Drop-in version bump. 3.3.1 (2018) predates the security fixes in 3.4.0 (`Object.prototype` pollution via `jQuery.extend`) and 3.5.0 (XSS via `htmlPrefilter`'s self-closing-tag regex); 3.7.1 is the current 3.x release.

Checked compatibility: the skin's JS uses no APIs removed or changed across the 3.x line, and builds no self-closing-tag HTML strings (the parsing behaviour 3.5 changed). Tested on a live station: modals, snapshot AJAX updates, theme toggle and the Highcharts loaders all behave identically on 3.7.1, in both themes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)