### PR TITLE
Remove the IE9 html5shiv conditional comment

### DIFF
--- a/skins/new-belchertown/header.html.tmpl
+++ b/skins/new-belchertown/header.html.tmpl
@@ -166,9 +166,6 @@
         <link rel="apple-touch-icon" sizes="168x168" href="$relative_url/images/station168.png">
         <link rel="apple-touch-icon" sizes="192x192" href="$relative_url/images/station192.png">
         
-        <!--[if lt IE 9]>
-        <script type='text/javascript' src='//cdnjs.cloudflare.com/ajax/libs/html5shiv/3.7.3/html5shiv.js'></script>
-        <![endif]-->
         #if $load_core_js
         <script defer type='text/javascript' src="//ajax.googleapis.com/ajax/libs/jquery/3.3.1/jquery.min.js"></script>
         <script defer type='text/javascript' src="//cdnjs.cloudflare.com/ajax/libs/moment.js/2.24.0/moment-with-locales.min.js"></script>


### PR DESCRIPTION
Conditional comments only execute in IE 9 and older, which nothing else in the skin's dependency stack supports — jQuery 3.x requires newer, and Bootstrap dropped IE entirely in v5 (v4 had already dropped IE8). The block is dead weight served in every page's HTML.

🤖 Generated with [Claude Code](https://claude.com/claude-code)