### PR TITLE
Remove jQuery usage from the MQTT live-data script

### DIFF
--- a/skins/new-belchertown/js/new-belchertown-charts.js.tmpl
+++ b/skins/new-belchertown/js/new-belchertown-charts.js.tmpl
@@ -319,9 +319,10 @@ function belchertown_detect_highcharts_modules(chartData) {
         return modules;
     }
 
-    jQuery.each(chartData, function(plotname, plotData) {
+    Object.keys(chartData).forEach(function(plotname) {
+        var plotData = chartData[plotname];
         if (!plotData || typeof plotData !== "object" || !plotData.options) {
-            return true;
+            return;
         }
 
         if (plotData.options.type === "gauge") {
@@ -335,15 +336,13 @@ function belchertown_detect_highcharts_modules(chartData) {
         }
 
         if (plotData.series && typeof plotData.series === "object") {
-            jQuery.each(plotData.series, function(seriesName, seriesData) {
+            Object.keys(plotData.series).forEach(function(seriesName) {
+                var seriesData = plotData.series[seriesName];
                 if (seriesData && seriesData.obsType === "windBarb") {
                     modules.add("windbarb");
                 }
-                return true;
             });
         }
-
-        return true;
     });
 
     return modules;
@@ -563,16 +562,18 @@ function showChart(json_file, prepend_renderTo = false) {
     });
 
     // Relative URL by finding what page we're on currently.
-    jQuery.ajax({
-        url: get_relative_url() + '/json/' + json_file + '.json',
-        dataType: 'json',
-        headers: {'Cache-Control': 'no-cache'},
-    }).done(function(data) {
+    fetch(get_relative_url() + '/json/' + json_file + '.json', {cache: "no-cache"}).then(function(resp) {
+        if (!resp.ok) {
+            throw new Error("HTTP error! Unable to load " + json_file + ".json");
+        }
+        return resp.json();
+    }).then(function(data) {
 
         var renderCharts = function() {
 
         // Loop through each chart name (e.g. chart1, chart2, chart3)
-        jQuery.each(data, function(plotname, obsname) {
+        Object.keys(data).forEach(function(plotname) {
+            var obsname = data[plotname];
             var observation_type = undefined;
             xAxis_categories = [];
             plot_tooltip_date_format = undefined;
@@ -583,51 +584,52 @@ function showChart(json_file, prepend_renderTo = false) {
 
             // Ignore the New Belchertown Version since this "plot" has no other options
             if (plotname == "belchertown_version") {
-                return true;
+                return;
             }
 
             // Ignore the generated timestamp since this "plot" has no other options
             if (plotname == "generated_timestamp") {
-                return true;
+                return;
             }
 
             // Ignore the chartgroup_title since this "plot" has no other options
             if (plotname == "chartgroup_title") {
-                return true;
+                return;
             }
 
             // Set the chart's tooltip date time format, then return since this "plot" has no other options
             if (plotname == "tooltip_date_format") {
                 tooltip_date_format = obsname;
-                return true;
+                return;
             }
 
             // Set the chart colors, then return right away since this "plot" has no other options
             if (plotname == "colors") {
                 colors = obsname.split(",");
-                return true;
+                return;
             }
 
             // Set the chart credits, then return right away since this "plot" has no other options
             if (plotname == "credits") {
                 credits = obsname.split(",")[0];
-                return true;
+                return;
             }
 
             // Set the chart credits url, then return right away since this "plot" has no other options
             if (plotname == "credits_url") {
                 credits_url = obsname.split(",")[0];
-                return true;
+                return;
             }
 
             // Set the chart credits position, then return right away since this "plot" has no other options
             if (plotname == "credits_position") {
                 credits_position = obsname;
-                return true;
+                return;
             }
 
             // Loop through each chart options
-            jQuery.each(data[plotname]["options"], function(optionName, optionVal) {
+            Object.keys(data[plotname]["options"]).forEach(function(optionName) {
+                var optionVal = data[plotname]["options"][optionName];
                 switch (optionName) {
                     case "type":
                         type = optionVal;
@@ -736,7 +738,10 @@ function showChart(json_file, prepend_renderTo = false) {
 
                                         this.subtitle.update({style: {color: darktheme_textcolor}});
 
-                                        this.chartBackground.attr({fill: jQuery(".highcharts-background").css("fill")});
+                                        var hcBackground = document.querySelector(".highcharts-background");
+                                        if (hcBackground) {
+                                            this.chartBackground.attr({fill: getComputedStyle(hcBackground).fill});
+                                        }
                                     } else {
                                         var lighttheme_textcolor = '#666666';
                                         for (var i = this.yAxis.length - 1; i >= 0; i--) {
@@ -932,7 +937,14 @@ function showChart(json_file, prepend_renderTo = false) {
             belchertown_debug(options.chart.renderTo + ": building a " + type + " chart");
 
             if (css_class) {
-                jQuery("#" + options.chart.renderTo).addClass(css_class);
+                var chartDiv = document.getElementById(options.chart.renderTo);
+                if (chartDiv) {
+                    css_class.split(/\s+/).forEach(function(cls) {
+                        if (cls) {
+                            chartDiv.classList.add(cls);
+                        }
+                    });
+                }
                 belchertown_debug(options.chart.renderTo + ": div id is " + options.chart.renderTo + " and adding CSS class: " + css_class);
             }
 
@@ -981,7 +993,7 @@ function showChart(json_file, prepend_renderTo = false) {
 
             // Build the series
             var i = 0;
-            jQuery.each(data[plotname]["series"], function(seriesName, seriesVal) {
+            Object.keys(data[plotname]["series"]).forEach(function(seriesName) {
                 observation_type = data[plotname]["series"][seriesName]["obsType"];
                 options.series[i] = data[plotname]["series"][seriesName];
                 i++;
@@ -1619,15 +1631,15 @@ function showChart(json_file, prepend_renderTo = false) {
             }
 
             // Apply any width, height CSS overrides to the parent div of the chart
-            if (css_height != "") {
-                jQuery("#" + options.chart.renderTo).parent().css({
-                    'height': css_height,
-                    'padding': '0px 15px',
-                    'margin-bottom': '20px'
-                });
+            var chartParent = document.getElementById(options.chart.renderTo);
+            chartParent = chartParent ? chartParent.parentElement : null;
+            if (css_height != "" && chartParent) {
+                chartParent.style.height = css_height;
+                chartParent.style.padding = '0px 15px';
+                chartParent.style.marginBottom = '20px';
             }
-            if (css_width != "") {
-                jQuery("#" + options.chart.renderTo).parent().css('width', css_width);
+            if (css_width != "" && chartParent) {
+                chartParent.style.width = css_width;
             }
 
             if (credits != "highcharts_default") {
@@ -1800,10 +1812,10 @@ function showChart(json_file, prepend_renderTo = false) {
                 // Add a visible placeholder for the skipped chart so users
                 // know why this chart is empty.
                 if (typeof options !== "undefined" && options.chart && options.chart.renderTo) {
-                    var failedChart = jQuery("#" + options.chart.renderTo);
-                    if (failedChart.length) {
+                    var failedChart = document.getElementById(options.chart.renderTo);
+                    if (failedChart) {
                         var unavailableObs = observation_type || plotname || belchertown_label_text("$obs.label.unknown_observation");
-                        failedChart.html(
+                        failedChart.innerHTML = (
                             '<div class="chart-unavailable" style="padding:14px 10px;text-align:center;color:#888;">' +
                             '<div>' + belchertown_label_html("$obs.label.chart_unavailable") + ' (' + belchertown_label_html("$obs.label.chart_unavailable_detail") + ')</div>' +
                             '<div style="margin-top:6px;font-weight:500;">' + belchertown_label_html("$obs.label.observation") + ': ' + belchertown_escape_html(unavailableObs) + '</div>' +
@@ -1812,7 +1824,7 @@ function showChart(json_file, prepend_renderTo = false) {
                     }
                 }
 
-                return true;
+                return;
             }
 
         });
@@ -1839,6 +1851,8 @@ function showChart(json_file, prepend_renderTo = false) {
             renderCharts();
         });
 
+    }).catch(function(err) {
+        belchertown_debug("Chart data load error: " + err.message + ". Skipping chart render.");
     });
 
 };

--- a/skins/new-belchertown/js/new-belchertown-forecast.js.tmpl
+++ b/skins/new-belchertown/js/new-belchertown-forecast.js.tmpl
@@ -42,7 +42,7 @@ function ajaxforecast() {
     forecast_start_refresh_timer();
 
     if (forecast_refresh_in_progress) {
-        return jQuery.Deferred().resolve().promise();
+        return Promise.resolve();
     }
 
     forecast_refresh_in_progress = true;
@@ -50,39 +50,39 @@ function ajaxforecast() {
     forecast_data = {};
     current_conditions_data = {};
 
-    const pCurrent = jQuery
-        .ajax({
-            url: forecast_json_url("current_conditions.json"),
-            dataType: "json",
-            cache: false,
-            headers: {"Cache-Control": "no-cache, no-store"},
+    const pCurrent = fetch(forecast_json_url("current_conditions.json"), {cache: "no-store"})
+        .then(function(resp) {
+            if (!resp.ok) {
+                throw new Error("HTTP error! Unable to load current_conditions.json");
+            }
+            return resp.json();
         })
-        .done(function(current_conditions) {
+        .then(function(current_conditions) {
             current_conditions_data = current_conditions;
         });
 
-    const pForecast = jQuery
-        .ajax({
-            url: forecast_json_url("forecast.json"),
-            dataType: "json",
-            cache: false,
-            headers: {"Cache-Control": "no-cache, no-store"},
+    const pForecast = fetch(forecast_json_url("forecast.json"), {cache: "no-store"})
+        .then(function(resp) {
+            if (!resp.ok) {
+                throw new Error("HTTP error! Unable to load forecast.json");
+            }
+            return resp.json();
         })
-        .done(function(forecast) {
+        .then(function(forecast) {
             forecast_data = forecast;
         });
 
     const promises = [pCurrent, pForecast];
 
-    return jQuery.when.apply(jQuery, promises)
+    return Promise.all(promises)
         .then(function() {
             update_current_conditions(current_conditions_data, forecast_data);
             update_forecast_data(forecast_data);
         })
-        .fail(function(err) {
+        .catch(function(err) {
             console.error("Forecast fetch failed:", err);
         })
-        .always(function() {
+        .finally(function() {
             forecast_refresh_in_progress = false;
         });
 }
@@ -272,9 +272,12 @@ function forecast_payload_source(data, fallbackProvider) {
 
 function forecast_render_source(data) {
     const source = forecast_payload_source(data, "");
-    jQuery(".forecast-source")
-        .text(forecast_sentence_text([forecast_label_text("$obs.label.source") + ": " + source]))
-        .attr("title", forecast_label_text("$obs.label.forecast_source") + ": " + source);
+    const sourceText = forecast_sentence_text([forecast_label_text("$obs.label.source") + ": " + source]);
+    const sourceTitle = forecast_label_text("$obs.label.forecast_source") + ": " + source;
+    document.querySelectorAll(".forecast-source").forEach(function(el) {
+        el.textContent = sourceText;
+        el.setAttribute("title", sourceTitle);
+    });
 }
 
 function forecast_current_observation_epoch(data) {
@@ -283,9 +286,15 @@ function forecast_current_observation_epoch(data) {
 }
 
 function forecast_observation_label(row, fallback) {
-    const labelCell = row.find(".station-observations-label").first().clone();
-    labelCell.find(".observation-source-info").remove();
-    return jQuery.trim(labelCell.text()) || fallback;
+    const labelCell = row.querySelector(".station-observations-label");
+    if (!labelCell) {
+        return fallback;
+    }
+    const clone = labelCell.cloneNode(true);
+    clone.querySelectorAll(".observation-source-info").forEach(function(el) {
+        el.remove();
+    });
+    return clone.textContent.trim() || fallback;
 }
 
 function forecast_observation_age_sentence(epoch) {
@@ -298,7 +307,7 @@ function forecast_observation_age_sentence(epoch) {
 }
 
 function forecast_ensure_observation_modal() {
-    if (jQuery("#observation-source-modal").length) {
+    if (document.getElementById("observation-source-modal")) {
         return;
     }
 
@@ -317,7 +326,7 @@ function forecast_ensure_observation_modal() {
     modal += "</div>";
     modal += "</div>";
     modal += "</div>";
-    jQuery("body").append(modal);
+    document.body.insertAdjacentHTML("beforeend", modal);
 }
 
 function forecast_render_observation_modal(observationKey) {
@@ -335,10 +344,14 @@ function forecast_render_observation_modal(observationKey) {
         body += "<p class='observation-source-modal-time'>" + forecast_escape_html(observedAt) + "</p>";
     }
 
-    jQuery("#observation-source-modal")
-        .data("observation", observationKey)
-        .find(".observation-source-modal-body")
-        .html(body);
+    const modal = document.getElementById("observation-source-modal");
+    if (modal) {
+        modal.dataset.observation = observationKey;
+        const modalBody = modal.querySelector(".observation-source-modal-body");
+        if (modalBody) {
+            modalBody.innerHTML = body;
+        }
+    }
 }
 
 function forecast_bind_observation_info() {
@@ -347,23 +360,29 @@ function forecast_bind_observation_info() {
     }
 
     forecast_observation_info_bound = true;
-    jQuery(document).on("click", ".observation-source-info", function(event) {
+    document.addEventListener("click", function(event) {
+        const trigger = event.target.closest(".observation-source-info");
+        if (!trigger) {
+            return;
+        }
         event.preventDefault();
         forecast_ensure_observation_modal();
-        forecast_render_observation_modal(jQuery(this).data("observation"));
-        jQuery("#observation-source-modal").modal("show");
+        forecast_render_observation_modal(trigger.dataset.observation);
+        bootstrap.Modal.getOrCreateInstance(document.getElementById("observation-source-modal")).show();
     });
 }
 
 function forecast_register_external_observation(observationKey, data, options) {
     options = options || {};
-    let row = jQuery(".station-observations tr").filter(function() {
-        return jQuery(this).data("observation") === observationKey;
-    }).first();
-    if (!row.length) {
-        row = jQuery(".station-observations ." + observationKey).closest("tr");
+    let row = Array.prototype.find.call(
+        document.querySelectorAll(".station-observations tr"),
+        function(tr) { return tr.dataset.observation === observationKey; }
+    ) || null;
+    if (!row) {
+        const obsCell = document.querySelector(".station-observations ." + observationKey);
+        row = obsCell ? obsCell.closest("tr") : null;
     }
-    if (!row.length) {
+    if (!row) {
         return;
     }
 
@@ -382,26 +401,31 @@ function forecast_register_external_observation(observationKey, data, options) {
         epoch: observationEpoch
     };
 
-    row.addClass("station-observation-row station-observation-row--external");
+    row.classList.add("station-observation-row", "station-observation-row--external");
 
-    let button = row.find(".observation-source-info").first();
-    if (!button.length) {
-        button = jQuery("<button type='button' class='observation-source-info'><i class='fa fa-info' aria-hidden='true'></i></button>");
-        row.find(".station-observations-label").first().append(button);
+    let button = row.querySelector(".observation-source-info");
+    if (!button) {
+        button = document.createElement("button");
+        button.type = "button";
+        button.className = "observation-source-info";
+        button.innerHTML = "<i class='fa fa-info' aria-hidden='true'></i>";
+        const labelCell = row.querySelector(".station-observations-label");
+        if (labelCell) {
+            labelCell.appendChild(button);
+        }
     }
 
-    button
-        .data("observation", observationKey)
-        .attr("aria-label", forecast_template_text("$obs.label.observation_source_information", [label]))
-        .attr("title", forecast_template_text("$obs.label.observation_source_information", [label]));
+    button.dataset.observation = observationKey;
+    button.setAttribute("aria-label", forecast_template_text("$obs.label.observation_source_information", [label]));
+    button.setAttribute("title", forecast_template_text("$obs.label.observation_source_information", [label]));
 
     forecast_bind_observation_info();
 }
 
 function forecast_register_external_observations(sourceKey, data, options) {
     const observationSources = forecast_station_observation_sources || {};
-    jQuery.each(observationSources, function(observationKey, metadata) {
-        metadata = metadata || {};
+    Object.keys(observationSources).forEach(function(observationKey) {
+        let metadata = observationSources[observationKey] || {};
         if (metadata["source_key"] !== sourceKey) {
             return;
         }
@@ -416,12 +440,16 @@ function forecast_register_external_observations(sourceKey, data, options) {
 function forecast_render_relative_timestamps() {
     if (forecast_last_updated_epoch !== null) {
         const forecastLabel = forecast_timestamp_label("$obs.label.forecast_last_updated");
-        jQuery(".forecast-subtitle")
-            .text(forecast_sentence_text([forecastLabel, forecast_relative_time(forecast_last_updated_epoch)]))
-            .attr("title", forecast_absolute_time(forecast_last_updated_epoch, '$obs.label.time_forecast_last_updated'));
+        const subtitleText = forecast_sentence_text([forecastLabel, forecast_relative_time(forecast_last_updated_epoch)]);
+        const subtitleTitle = forecast_absolute_time(forecast_last_updated_epoch, '$obs.label.time_forecast_last_updated');
+        document.querySelectorAll(".forecast-subtitle").forEach(function(el) {
+            el.textContent = subtitleText;
+            el.setAttribute("title", subtitleTitle);
+        });
     }
 
-    const activeObservation = jQuery("#observation-source-modal").data("observation");
+    const observationModal = document.getElementById("observation-source-modal");
+    const activeObservation = observationModal ? observationModal.dataset.observation : undefined;
     if (activeObservation) {
         forecast_render_observation_modal(activeObservation);
     }
@@ -517,11 +545,11 @@ function forecast_alert_in_effect_text(alertObj) {
 }
 
 function forecast_active_alert_modal() {
-    return jQuery(".modal.in[id^='forecast-alert-'], .modal.show[id^='forecast-alert-']").first();
+    return document.querySelector(".modal.in[id^='forecast-alert-'], .modal.show[id^='forecast-alert-']");
 }
 
 function forecast_alert_modal_by_id(id) {
-    return id ? jQuery(document.getElementById(id)) : jQuery();
+    return id ? document.getElementById(id) : null;
 }
 
 function forecast_alert_modal_html(forecastAlertId, forecastAlertTitleId, alertData) {
@@ -547,28 +575,31 @@ function forecast_alert_modal_html(forecastAlertId, forecastAlertTitleId, alertD
 }
 
 function forecast_update_alert_modal(modal, forecastAlertTitleId, alertData) {
-    modal
-        .addClass("forecast-alert-modal")
-        .attr("aria-labelledby", forecastAlertTitleId);
-    modal.find(".modal-title")
-        .attr("id", forecastAlertTitleId)
-        .html(forecast_escape_html(alertData["title"]));
-    modal.find(".modal-body").html(alertData["body"]);
+    modal.classList.add("forecast-alert-modal");
+    modal.setAttribute("aria-labelledby", forecastAlertTitleId);
+    var modalTitle = modal.querySelector(".modal-title");
+    if (modalTitle) {
+        modalTitle.id = forecastAlertTitleId;
+        modalTitle.innerHTML = forecast_escape_html(alertData["title"]);
+    }
+    var modalBody = modal.querySelector(".modal-body");
+    if (modalBody) {
+        modalBody.innerHTML = alertData["body"];
+    }
 }
 
 function forecast_remove_stale_alert_modals(currentAlertIds, activeAlertId) {
-    jQuery(".forecast-alert-modal, .modal[id^='forecast-alert-']").each(function() {
-        var modal = jQuery(this);
-        var modalId = modal.attr("id");
+    document.querySelectorAll(".forecast-alert-modal, .modal[id^='forecast-alert-']").forEach(function(modal) {
+        var modalId = modal.id;
 
         if (currentAlertIds[modalId]) {
             return;
         }
 
         if (modalId === activeAlertId) {
-            modal.one("hidden.bs.modal", function() {
-                jQuery(this).remove();
-            });
+            modal.addEventListener("hidden.bs.modal", function() {
+                modal.remove();
+            }, {once: true});
             return;
         }
 
@@ -581,17 +612,19 @@ function show_forcast_alert(data) {
     var i, forecast_alerts, forecast_alert_title, forecast_alert_body;
     var forecast_alert_link, forecast_alert_expires, forecast_alert_in_effect, alert_link;
     var activeAlertModal = forecast_active_alert_modal();
-    var activeAlertId = activeAlertModal.attr("id") || "";
+    var activeAlertId = (activeAlertModal && activeAlertModal.id) || "";
     var currentAlertIds = {};
-    var alertContainer = jQuery(".wx-stn-alert-text");
+    var alertContainer = document.querySelector(".wx-stn-alert-text");
     forecast_alerts = [];
 
-    if (activeAlertModal.length && activeAlertModal.closest(".wx-stn-alert-text").length) {
-        activeAlertModal.detach().appendTo("body");
+    if (activeAlertModal && activeAlertModal.closest(".wx-stn-alert-text")) {
+        document.body.appendChild(activeAlertModal);
     }
 
     // Empty the alert links from the previous run without removing any active modal node.
-    alertContainer.empty();
+    if (alertContainer) {
+        alertContainer.innerHTML = "";
+    }
 
     if (Array.isArray(data['alerts'])) {
         for (i = 0; i < data['alerts'].length; i++) {
@@ -629,19 +662,25 @@ function show_forcast_alert(data) {
 
             currentAlertIds[forecastAlertId] = true;
             alert_link = "<i class='fa fa-exclamation-triangle' aria-hidden='true'></i> <a href='#" + forecastAlertId + "' data-bs-toggle='modal' data-bs-target='#" + forecastAlertId + "'>" + forecast_escape_html(alertLinkText) + "</a><br>";
-            alertContainer.append(alert_link);
+            if (alertContainer) {
+                alertContainer.insertAdjacentHTML("beforeend", alert_link);
+            }
 
             var forecast_alert_modal = forecast_alert_modal_by_id(forecastAlertId);
-            if (forecast_alert_modal.length) {
+            if (forecast_alert_modal) {
                 forecast_update_alert_modal(forecast_alert_modal, forecastAlertTitleId, forecast_alerts[i]);
             } else {
-                jQuery("body").append(forecast_alert_modal_html(forecastAlertId, forecastAlertTitleId, forecast_alerts[i]));
+                document.body.insertAdjacentHTML("beforeend", forecast_alert_modal_html(forecastAlertId, forecastAlertTitleId, forecast_alerts[i]));
             }
         }
-        jQuery(".wx-stn-alert").show();
+        document.querySelectorAll(".wx-stn-alert").forEach(function(el) {
+            el.style.display = "block";
+        });
     } else {
         belchertown_debug("Forecast: There are no forecast alerts");
-        jQuery(".wx-stn-alert").hide();
+        document.querySelectorAll(".wx-stn-alert").forEach(function(el) {
+            el.style.display = "none";
+        });
     }
 
     forecast_remove_stale_alert_modals(currentAlertIds, activeAlertId);
@@ -698,14 +737,21 @@ function update_current_conditions(data, forecastData) {
             w34icon = resolveIconForProvider(fallbackPeriod["summary"], sourceProvider);
         }
         const wxicon = get_relative_url() + "/images/" + w34icon + ".png";
-        jQuery("#wxicon").attr("src", wxicon);
+        const wxiconEl = document.getElementById("wxicon");
+        if (wxiconEl) {
+            wxiconEl.src = wxicon;
+        }
 
         try {
-            jQuery(".current-obs-text").html(cc["summary"] || fallbackPeriod["summary"] || "");
+            document.querySelectorAll(".current-obs-text").forEach(function(el) {
+                el.innerHTML = cc["summary"] || fallbackPeriod["summary"] || "";
+            });
         } catch (err) { /* silent */}
 
         try {
-            jQuery(".station-observations .visibility").html(forecast_visibility_text(cc["visibility"], cc["visibilityQualifier"]));
+            document.querySelectorAll(".station-observations .visibility").forEach(function(el) {
+                el.innerHTML = forecast_visibility_text(cc["visibility"], cc["visibilityQualifier"]);
+            });
         } catch (err) { /* silent */}
 
         forecast_register_external_observations("current_conditions", data);
@@ -1002,8 +1048,7 @@ function forecast_render_daily_tiles(dailySource, maxTiles) {
 function forecast_fit_daily_condition_text() {
     const minFontSize = 11;
 
-    jQuery(".day_forecasts .forecast-day.forecast-tile").each(function() {
-        const tile = this;
+    document.querySelectorAll(".day_forecasts .forecast-day.forecast-tile").forEach(function(tile) {
         const conditions = tile.querySelector(".forecast-conditions");
         const text = tile.querySelector(".forecast-condition-text");
         if (!conditions || !text || conditions.offsetParent === null) {
@@ -1034,15 +1079,24 @@ function forecast_update_aqi(data) {
             const aqiPeriod = data["aqi"][0]["response"][0]["periods"][0];
             const aqiValue = aqiPeriod["aqi"];
             const aqiCategory = forecast_aqi_translate(aqiPeriod["category"]);
-            jQuery(".wx-aqi").text(aqiValue);
-            jQuery(".wx-aqi-category").text(aqiCategory);
+            document.querySelectorAll(".wx-aqi").forEach(function(el) {
+                el.textContent = aqiValue;
+            });
+            document.querySelectorAll(".wx-aqi-category").forEach(function(el) {
+                el.textContent = aqiCategory;
+            });
             get_aqi_color(aqiValue);
             if ("$Extras.aqi_location_enabled" === "1") {
                 const aqiPlace = data["aqi"][0]["response"][0]["place"]["name"] || "";
-                jQuery(".aqi_location_outer").html(aqiPlace ? "<br>" + aqiPlace : "").css('textTransform', 'capitalize');
+                document.querySelectorAll(".aqi_location_outer").forEach(function(el) {
+                    el.innerHTML = aqiPlace ? "<br>" + aqiPlace : "";
+                    el.style.textTransform = "capitalize";
+                });
             }
             try {
-                jQuery(".station-observations .aqi").text(aqiValue + " (" + aqiCategory + ")");
+                document.querySelectorAll(".station-observations .aqi").forEach(function(el) {
+                    el.textContent = aqiValue + " (" + aqiCategory + ")";
+                });
             } catch (err) {
                 // AQI not in the station observation table, so silently exit
             }
@@ -1052,12 +1106,22 @@ function forecast_update_aqi(data) {
             });
         } else if (data["aqi"] && data["aqi"][0] && data["aqi"][0]["success"] && data["aqi"][0]["error"] && data["aqi"][0]["error"]["code"] === "warn_no_data") {
             const aqiNoDataCategory = forecast_aqi_translate("");
-            jQuery(".wx-aqi").text(forecast_label_text("$obs.label.no_data"));
-            jQuery(".wx-aqi-category").text(aqiNoDataCategory);
+            document.querySelectorAll(".wx-aqi").forEach(function(el) {
+                el.textContent = forecast_label_text("$obs.label.no_data");
+            });
+            document.querySelectorAll(".wx-aqi-category").forEach(function(el) {
+                el.textContent = aqiNoDataCategory;
+            });
             clear_aqi_color();
-            if ("$Extras.aqi_location_enabled" === "1") jQuery(".aqi_location_outer").html("");
+            if ("$Extras.aqi_location_enabled" === "1") {
+                document.querySelectorAll(".aqi_location_outer").forEach(function(el) {
+                    el.innerHTML = "";
+                });
+            }
             try {
-                jQuery(".station-observations .aqi").text(forecast_label_text("$obs.label.no_data") + " (" + aqiNoDataCategory + ")");
+                document.querySelectorAll(".station-observations .aqi").forEach(function(el) {
+                    el.textContent = forecast_label_text("$obs.label.no_data") + " (" + aqiNoDataCategory + ")";
+                });
             } catch (err) {
                 // AQI not in the station observation table, so silently exit
             }
@@ -1086,9 +1150,18 @@ function forecast_render_common(data) {
 
     forecast_render_source(data);
     forecast_register_external_observations("forecast", data, {epoch: lastUpdated});
-    jQuery(".onehr_forecasts").html(forecast_render_hourly_tiles(hourly, 16, "forecast-1hour"));
-    jQuery(".threehr_forecasts").html(forecast_render_hourly_tiles(threeHourly, 8, "forecast-3hour"));
-    jQuery(".day_forecasts").html(forecast_render_daily_tiles(daily, 7));
+    const onehrHtml = forecast_render_hourly_tiles(hourly, 16, "forecast-1hour");
+    const threehrHtml = forecast_render_hourly_tiles(threeHourly, 8, "forecast-3hour");
+    const dailyHtml = forecast_render_daily_tiles(daily, 7);
+    document.querySelectorAll(".onehr_forecasts").forEach(function(el) {
+        el.innerHTML = onehrHtml;
+    });
+    document.querySelectorAll(".threehr_forecasts").forEach(function(el) {
+        el.innerHTML = threehrHtml;
+    });
+    document.querySelectorAll(".day_forecasts").forEach(function(el) {
+        el.innerHTML = dailyHtml;
+    });
     forecast_render_relative_timestamps();
     forecast_start_relative_timer();
     if (typeof forecast_sync_row_height === "function") {
@@ -1104,7 +1177,9 @@ function update_forecast_data(data) {
     belchertown_debug(data);
 
     if (forecast_provider == "N/A") {
-        jQuery(".forecastrow").hide();
+        document.querySelectorAll(".forecastrow").forEach(function(el) {
+            el.style.display = "none";
+        });
         belchertown_debug("Forecast: No provider, hiding forecastrow");
         return;
     } else if (forecast_has_common_schema(data)) {

--- a/skins/new-belchertown/js/new-belchertown-mqtt.js.tmpl
+++ b/skins/new-belchertown/js/new-belchertown-mqtt.js.tmpl
@@ -15,25 +15,23 @@ function ajaximages(section = false, reload_timer_interval_seconds = false) {
             var radar_img = document.querySelectorAll(".radar-map img")[0].src;
             var new_radar_img = radar_img + "&t=" + Math.floor(Math.random() * 999999999);
             document.querySelectorAll(".radar-map img")[0].src = new_radar_img;
-            //var radar_html = jQuery('.radar-map').children('img').attr('src').split('?')[0] // Get the img src and remove everything after "?" so we don't stack ?'s onto the image during updates
-            //jQuery('.radar-map').children('img').attr('src', radar_html + "?" + Math.floor(Math.random() * 999999999));
         }
         // Reload iframe - https://stackoverflow.com/a/4249946/1177153
         if (document.querySelectorAll(".radar-map iframe").length > 0) {
-            jQuery(".radar-map iframe").each(function() {
-                jQuery(this).attr('src', function(i, val) {return val;});
+            document.querySelectorAll(".radar-map iframe").forEach(function(frame) {
+                frame.src = frame.src;
             });
         }
     } else if (!section || section != "radar") {
         belchertown_debug("Updating " + section + " images");
         // Reload images
-        jQuery('.' + section + ' img').each(function() {
-            new_image_url = jQuery(this).attr('src').split('?')[0] + "?" + Math.floor(Math.random() * 999999999);
-            jQuery(this).attr('src', new_image_url);
+        document.querySelectorAll('.' + section + ' img').forEach(function(img) {
+            new_image_url = img.getAttribute('src').split('?')[0] + "?" + Math.floor(Math.random() * 999999999);
+            img.src = new_image_url;
         });
         // Reload iframes
-        jQuery('.' + section + ' iframe').each(function() {
-            jQuery(this).attr('src', function(i, val) {return val;});
+        document.querySelectorAll('.' + section + ' iframe').forEach(function(frame) {
+            frame.src = frame.src;
         });
     }
     // Set the new timer
@@ -91,12 +89,12 @@ function mqtt_ensure_status_info_button() {
         return;
     }
 
-    var updated = jQuery(".updated").first();
-    if (!updated.length || jQuery(".mqtt-status-info").length) {
+    var updated = document.querySelector(".updated");
+    if (!updated || document.querySelector(".mqtt-status-info")) {
         return;
     }
 
-    updated.after(
+    updated.insertAdjacentHTML("afterend",
         " <button type='button' class='mqtt-status-info' aria-label='" + belchertown_label_html("$obs.label.mqtt_live_update_details") + "'>" +
         "<i class='fa fa-info' aria-hidden='true'></i>" +
         "</button>"
@@ -108,7 +106,7 @@ function mqtt_ensure_status_modal() {
         return;
     }
 
-    if (jQuery("#mqtt-status-modal").length) {
+    if (document.getElementById("mqtt-status-modal")) {
         return;
     }
 
@@ -137,7 +135,7 @@ function mqtt_ensure_status_modal() {
     modal += "</div>";
     modal += "</div>";
     modal += "</div>";
-    jQuery("body").append(modal);
+    document.body.insertAdjacentHTML("beforeend", modal);
 }
 
 function mqtt_modal_normalized_text(value) {
@@ -188,16 +186,16 @@ function mqtt_set_latest_packet_data(payload) {
 }
 
 function mqtt_render_live_data_modal(modal) {
-    var container = modal.find(".mqtt-status-live-data");
+    var container = modal.querySelector(".mqtt-status-live-data");
     var rows = mqtt_latest_packet_rows;
     var html = "";
 
-    if (!container.length) {
+    if (!container) {
         return;
     }
 
     if (!rows.length) {
-        container.hide();
+        container.style.display = "none";
         return;
     }
 
@@ -210,19 +208,28 @@ function mqtt_render_live_data_modal(modal) {
     });
     html += "</tbody></table>";
 
-    container.find(".mqtt-status-live-data-rows").html(html);
-    container.show();
+    var rowsContainer = container.querySelector(".mqtt-status-live-data-rows");
+    if (rowsContainer) {
+        rowsContainer.innerHTML = html;
+    }
+    container.style.display = "";
 }
 
 function mqtt_render_status_modal() {
-    var modal = jQuery("#mqtt-status-modal");
-    if (!modal.length) {
+    var modal = document.getElementById("mqtt-status-modal");
+    if (!modal) {
         return;
     }
 
-    modal.find(".mqtt-status-detail-message").text(mqtt_status_detail.message || "");
-    modal.find(".mqtt-status-detail-relative").text(mqtt_status_detail.relative_time || "");
-    modal.find(".mqtt-status-detail-absolute").text(mqtt_status_detail.absolute_time || "");
+    var setText = function(selector, value) {
+        var el = modal.querySelector(selector);
+        if (el) {
+            el.textContent = value;
+        }
+    };
+    setText(".mqtt-status-detail-message", mqtt_status_detail.message || "");
+    setText(".mqtt-status-detail-relative", mqtt_status_detail.relative_time || "");
+    setText(".mqtt-status-detail-absolute", mqtt_status_detail.absolute_time || "");
     mqtt_render_live_data_modal(modal);
 }
 
@@ -237,23 +244,21 @@ function mqtt_set_status_detail(message, epoch) {
 }
 
 function mqtt_show_status_modal() {
-    var modal = jQuery("#mqtt-status-modal");
-    if (!modal.length) {
+    var modal = document.getElementById("mqtt-status-modal");
+    if (!modal || typeof bootstrap === "undefined" || !bootstrap.Modal) {
         return;
     }
 
-    if (jQuery.fn.modal) {
-        modal.modal("show");
-    }
+    bootstrap.Modal.getOrCreateInstance(modal).show();
 }
 
 function mqtt_hide_status_modal() {
-    var modal = jQuery("#mqtt-status-modal");
-    if (!modal.length || !jQuery.fn.modal) {
+    var modal = document.getElementById("mqtt-status-modal");
+    if (!modal || typeof bootstrap === "undefined" || !bootstrap.Modal) {
         return;
     }
 
-    modal.modal("hide");
+    bootstrap.Modal.getOrCreateInstance(modal).hide();
 }
 
 function mqtt_bind_status_info_button() {
@@ -262,14 +267,17 @@ function mqtt_bind_status_info_button() {
     }
 
     mqtt_status_info_handler_bound = true;
-    jQuery(document).on("click.belchertownMqttStatus", ".mqtt-status-info", function(event) {
-        event.preventDefault();
-        mqtt_ensure_status_modal();
-        mqtt_render_status_modal();
-        mqtt_show_status_modal();
-    });
-    jQuery(document).on("click.belchertownMqttStatus", ".mqtt-status-modal-dismiss", function() {
-        mqtt_hide_status_modal();
+    document.addEventListener("click", function(event) {
+        if (event.target.closest(".mqtt-status-info")) {
+            event.preventDefault();
+            mqtt_ensure_status_modal();
+            mqtt_render_status_modal();
+            mqtt_show_status_modal();
+            return;
+        }
+        if (event.target.closest(".mqtt-status-modal-dismiss")) {
+            mqtt_hide_status_modal();
+        }
     });
 }
 
@@ -313,12 +321,14 @@ function mqtt_render_relative_updated_status() {
         mqtt_relative_updated_detail_message || mqtt_relative_updated_message,
         mqtt_relative_updated_epoch
     );
-    var updated = jQuery(".updated")
-        .text(mqtt_sentence_text([mqtt_relative_updated_message, relative_time]))
-        .removeAttr("title");
-    if (mqtt_relative_updated_suffix_html) {
-        updated.append(mqtt_relative_updated_suffix_html);
-    }
+    var updatedText = mqtt_sentence_text([mqtt_relative_updated_message, relative_time]);
+    document.querySelectorAll(".updated").forEach(function(el) {
+        el.textContent = updatedText;
+        el.removeAttribute("title");
+        if (mqtt_relative_updated_suffix_html) {
+            el.insertAdjacentHTML("beforeend", mqtt_relative_updated_suffix_html);
+        }
+    });
 }
 
 function mqtt_start_relative_updated_timer() {
@@ -344,19 +354,25 @@ function mqtt_clear_receiving_indicator() {
         clearTimeout(mqtt_receiving_indicator_timeout);
         mqtt_receiving_indicator_timeout = null;
     }
-    jQuery(".onlineMarker").removeClass("mqtt-receiving");
+    document.querySelectorAll(".onlineMarker").forEach(function(el) {
+        el.classList.remove("mqtt-receiving");
+    });
 }
 
 function mqtt_mark_receiving_data() {
-    var marker = jQuery(".onlineMarker");
+    var markers = document.querySelectorAll(".onlineMarker");
     if (mqtt_receiving_indicator_timeout !== null) {
         clearTimeout(mqtt_receiving_indicator_timeout);
     }
-    marker.removeClass("mqtt-receiving");
-    if (marker.length) {
-        marker[0].offsetWidth;
+    markers.forEach(function(el) {
+        el.classList.remove("mqtt-receiving");
+    });
+    if (markers.length) {
+        markers[0].offsetWidth;
     }
-    marker.addClass("mqtt-receiving");
+    markers.forEach(function(el) {
+        el.classList.add("mqtt-receiving");
+    });
     mqtt_receiving_indicator_timeout = setTimeout(function() {
         mqtt_receiving_indicator_timeout = null;
         mqtt_clear_receiving_indicator();
@@ -366,13 +382,20 @@ function mqtt_mark_receiving_data() {
 function mqtt_set_updated_html(html) {
     mqtt_clear_relative_updated_status();
     mqtt_clear_receiving_indicator();
-    jQuery(".updated").removeAttr("title").html(html);
+    document.querySelectorAll(".updated").forEach(function(el) {
+        el.removeAttribute("title");
+        el.innerHTML = html;
+    });
 }
 
 function mqtt_set_updated_text(text) {
     mqtt_clear_relative_updated_status();
     mqtt_clear_receiving_indicator();
-    jQuery(".updated").removeAttr("title").text(belchertown_label_text(text));
+    var updatedText = belchertown_label_text(text);
+    document.querySelectorAll(".updated").forEach(function(el) {
+        el.removeAttribute("title");
+        el.textContent = updatedText;
+    });
 }
 
 function mqtt_set_relative_updated_status(message, epoch, suffix_html, detail_message) {
@@ -395,7 +418,9 @@ function mqtt_restart_live_updates(event) {
         event.preventDefault();
     }
 
-    jQuery(".restart-interval").prop("disabled", true);
+    document.querySelectorAll(".restart-interval").forEach(function(el) {
+        el.disabled = true;
+    });
     mqtt_clear_reconnect_timeout();
     mqtt_reset_reconnect_backoff();
     mqtt_set_updated_text("$obs.label.mqtt_websockets_connecting");
@@ -404,7 +429,7 @@ function mqtt_restart_live_updates(event) {
     if (typeof ajaxweewx === "function") {
         reloadPromise = ajaxweewx();
     } else {
-        reloadPromise = jQuery.Deferred().resolve(null).promise();
+        reloadPromise = Promise.resolve(null);
     }
 
     reloadPromise.then(function(weewx_data) {
@@ -438,7 +463,11 @@ function mqtt_bind_restart_button() {
     }
 
     mqtt_restart_handler_bound = true;
-    jQuery(document).on("click.belchertownMqttRestart", ".restart-interval", mqtt_restart_live_updates);
+    document.addEventListener("click", function(event) {
+        if (event.target.closest(".restart-interval")) {
+            mqtt_restart_live_updates(event);
+        }
+    });
 }
 
 mqtt_bind_restart_button();
@@ -506,13 +535,37 @@ function mqtt_schedule_reconnect(reason, reset_backoff) {
     }, delay_ms);
 }
 
+function mqtt_set_display(selector, value) {
+    document.querySelectorAll(selector).forEach(function(el) {
+        el.style.display = value;
+    });
+}
+
+function mqtt_set_html(selector, html) {
+    if (typeof html === "undefined") {
+        return; // match jQuery .html(undefined), which left content unchanged
+    }
+    document.querySelectorAll(selector).forEach(function(el) {
+        el.innerHTML = html;
+    });
+}
+
+function mqtt_set_text(selector, text) {
+    if (typeof text === "undefined") {
+        return; // match jQuery .text(undefined), which left content unchanged
+    }
+    document.querySelectorAll(selector).forEach(function(el) {
+        el.textContent = text;
+    });
+}
+
 function mqtt_set_disconnected_status(message, epoch, show_restart) {
     mqttConnected = false;
     mqtt_clear_activity_timeout();
     mqtt_clear_stale_timeout();
-    jQuery(".onlineMarker").hide();
-    jQuery(".offlineMarker").show();
-    jQuery(".loadingMarker").hide();
+    mqtt_set_display(".onlineMarker", "none");
+    mqtt_set_display(".offlineMarker", "");
+    mqtt_set_display(".loadingMarker", "none");
 
     var updated_epoch = epoch || mqtt_last_data_epoch || "$current.dateTime.raw";
     var restart_button = show_restart ? mqtt_restart_button_html() : "";
@@ -624,9 +677,9 @@ function connect() {
     }
     reported = belchertown_label_text("$obs.label.mqtt_websockets_connecting") + " " + belchertown_label_text("$obs.label.header_last_updated") + " " + updated;
     mqtt_set_updated_text(reported);
-    jQuery(".onlineMarker").hide();
-    jQuery(".offlineMarker").hide();
-    jQuery(".loadingMarker").show();
+    mqtt_set_display(".onlineMarker", "none");
+    mqtt_set_display(".offlineMarker", "none");
+    mqtt_set_display(".loadingMarker", "");
     belchertown_debug("MQTT: UI markers updated for connection state");
 
     // #if $Extras.has_key("mqtt_websockets_host_kiosk") and $Extras.mqtt_websockets_host_kiosk != ""
@@ -714,9 +767,9 @@ function onConnect() {
         reported = belchertown_label_text("$obs.label.mqtt_websockets_waiting") + " " + belchertown_label_text("$obs.label.header_last_updated") + " " + updated;
     }
     mqtt_set_updated_text(reported);
-    jQuery(".onlineMarker").hide();
-    jQuery(".offlineMarker").hide();
-    jQuery(".loadingMarker").show();
+    mqtt_set_display(".onlineMarker", "none");
+    mqtt_set_display(".offlineMarker", "none");
+    mqtt_set_display(".loadingMarker", "");
     belchertown_debug("MQTT: Subscribing to topic: $Extras.mqtt_websockets_topic");
     client.subscribe("$Extras.mqtt_websockets_topic");
     belchertown_debug("MQTT: Topic subscription request sent");
@@ -823,9 +876,9 @@ function get_mqtt_status_elements() {
     }
 
     mqttStatusElements = {
-        onlineMarkerEl: jQuery(".onlineMarker"),
-        offlineMarkerEl: jQuery(".offlineMarker"),
-        loadingMarkerEl: jQuery(".loadingMarker")
+        onlineMarkerEl: document.querySelectorAll(".onlineMarker"),
+        offlineMarkerEl: document.querySelectorAll(".offlineMarker"),
+        loadingMarkerEl: document.querySelectorAll(".loadingMarker")
     };
 
     return mqttStatusElements;
@@ -839,8 +892,8 @@ function get_station_observation_cache() {
     stationObservationElementsByKey = {};
     stationObservationUseGroupingByKey = {};
 
-    jQuery('.station-observations').find("span").each(function() {
-        var rawClass = jQuery(this).attr("class");
+    document.querySelectorAll(".station-observations span").forEach(function(span) {
+        var rawClass = span.getAttribute("class");
         if (!rawClass) {
             return;
         }
@@ -855,7 +908,7 @@ function get_station_observation_cache() {
         }
 
         if (!stationObservationElementsByKey.hasOwnProperty(elementClass)) {
-            stationObservationElementsByKey[elementClass] = jQuery("." + elementClass);
+            stationObservationElementsByKey[elementClass] = document.querySelectorAll("." + elementClass);
             stationObservationUseGroupingByKey[elementClass] = !(elementClass === "barometer" || elementClass === "pressure" || elementClass === "altimeter" || elementClass === "cloudbase");
         }
     });
@@ -912,7 +965,7 @@ function onMessageArrived(message) {
     var payload_size = message.payloadString.length;
     belchertown_debug("MQTT: [Msg #" + mqtt_message_count + "] Message received - Size: " + payload_size + " bytes, Topic: " + message.destinationName);
     try {
-        mqtt_payload = jQuery.parseJSON(message.payloadString);
+        mqtt_payload = JSON.parse(message.payloadString);
         mqtt_set_latest_packet_data(mqtt_payload);
         schedule_mqtt_ui_update(mqtt_payload);
         belchertown_debug("MQTT: [Msg #" + mqtt_message_count + "] Message processed successfully");
@@ -965,8 +1018,8 @@ function parse_mqtt_number(payload, key) {
 }
 
 function update_almanac_diagram_from_mqtt(payload) {
-    var diagram = jQuery(".almanac-diagram");
-    if (!diagram.length) {
+    var diagram = document.querySelector(".almanac-diagram");
+    if (!diagram) {
         return;
     }
 
@@ -982,12 +1035,12 @@ function update_almanac_diagram_from_mqtt(payload) {
 
     var getDiagramValue = function(dataKey) {
         var attrName = "data-" + dataKey.replace(/([A-Z])/g, "-$1").toLowerCase();
-        var attrValue = parseFloat(diagram.attr(attrName));
+        var attrValue = parseFloat(diagram.getAttribute(attrName));
         if (isFinite(attrValue)) {
             return attrValue;
         }
 
-        var dataValue = parseFloat(diagram.data(dataKey));
+        var dataValue = parseFloat(diagram.dataset[dataKey]);
         return isFinite(dataValue) ? dataValue : null;
     };
 
@@ -1007,29 +1060,25 @@ function update_almanac_diagram_from_mqtt(payload) {
             set_epoch: getDiagramValue("moonSetEpoch"),
             x_offset: getDiagramValue("moonXOffset")
         },
-        centering_mode: String(diagram.attr("data-centering-mode") || diagram.data("centeringMode") || "off").toLowerCase(),
+        centering_mode: String(diagram.getAttribute("data-centering-mode") || "off").toLowerCase(),
         current_ts: currentTs === null ? getDiagramValue("currentTs") : currentTs
     };
 
     if (solarAz !== null) {
         diagramData.sun.azimuth = solarAz;
-        diagram.data("sunAz", solarAz);
-        diagram.attr("data-sun-az", solarAz.toFixed(3));
+        diagram.setAttribute("data-sun-az", solarAz.toFixed(3));
     }
     if (solarAlt !== null) {
         diagramData.sun.altitude = solarAlt;
-        diagram.data("sunAlt", solarAlt);
-        diagram.attr("data-sun-alt", solarAlt.toFixed(3));
+        diagram.setAttribute("data-sun-alt", solarAlt.toFixed(3));
     }
     if (lunarAz !== null) {
         diagramData.moon.azimuth = lunarAz;
-        diagram.data("moonAz", lunarAz);
-        diagram.attr("data-moon-az", lunarAz.toFixed(3));
+        diagram.setAttribute("data-moon-az", lunarAz.toFixed(3));
     }
     if (lunarAlt !== null) {
         diagramData.moon.altitude = lunarAlt;
-        diagram.data("moonAlt", lunarAlt);
-        diagram.attr("data-moon-alt", lunarAlt.toFixed(3));
+        diagram.setAttribute("data-moon-alt", lunarAlt.toFixed(3));
     }
 
     belchertown_debug(
@@ -1043,7 +1092,7 @@ function update_almanac_diagram_from_mqtt(payload) {
 // Handle MQTT message
 function update_current_wx(data) {
     if (typeof data === "string") {
-        data = jQuery.parseJSON(data);
+        data = JSON.parse(data);
     }
     data = normalize_mqtt_payload(data);
     mqtt_note_message_activity(data);
@@ -1114,9 +1163,9 @@ function update_current_wx(data) {
         mqtt_set_relative_updated_status(updated_text, epoch);
     }
     // If we're in this function, show the online beacon and hide the others
-    onlineMarkerEl.show(); // Show the online beacon
-    offlineMarkerEl.hide();
-    loadingMarkerEl.hide();
+    onlineMarkerEl.forEach(function(el) { el.style.display = ""; }); // Show the online beacon
+    offlineMarkerEl.forEach(function(el) { el.style.display = "none"; });
+    loadingMarkerEl.forEach(function(el) { el.style.display = "none"; });
 
     // Update the station observation box elements
     station_mqtt_data = Object.keys(data); // Turn data (mqtt message) into an object we can forEach
@@ -1170,7 +1219,9 @@ function update_current_wx(data) {
             useGrouping: stationObservationUseGroupingByKey[observationKey]
         }) + unit_label_array[observationKey];
 
-        stationObservationElementsByKey[observationKey].html(html_output);
+        stationObservationElementsByKey[observationKey].forEach(function(el) {
+            el.innerHTML = html_output;
+        });
     });
     // End dynamic station observation box
 
@@ -1180,79 +1231,79 @@ function update_current_wx(data) {
         // Help from: https://stackoverflow.com/a/40152286/1177153 and https://stackoverflow.com/a/31581206/1177153
         outTemp = parseFloat(parseFloat(data["outTemp_F"])).toLocaleString("$system_locale_js", {minimumFractionDigits: unit_rounding_array["outTemp"], maximumFractionDigits: unit_rounding_array["outTemp"]});
         get_outTemp_color("degree_F", outTemp);
-        jQuery(".outtemp").html(outTemp);
+        mqtt_set_html(".outtemp", outTemp);
     }
 
     // Temperature C
     if (data.hasOwnProperty("outTemp_C")) {
         outTemp = parseFloat(parseFloat(data["outTemp_C"])).toLocaleString("$system_locale_js", {minimumFractionDigits: unit_rounding_array["outTemp"], maximumFractionDigits: unit_rounding_array["outTemp"]});
         get_outTemp_color("degree_C", outTemp);
-        jQuery(".outtemp").html(outTemp);
+        mqtt_set_html(".outtemp", outTemp);
     }
 
     // Apparent Temperature US
     if (data.hasOwnProperty("appTemp_F")) {
-        jQuery(".feelslike").text(belchertown_label_text("$obs.label.feels_like") + " " + parseFloat(parseFloat(data["appTemp_F"])).toLocaleString("$system_locale_js", {minimumFractionDigits: unit_rounding_array["outTemp"], maximumFractionDigits: unit_rounding_array["outTemp"]}) + " " + belchertown_label_text("$unit.label.outTemp"));
+        mqtt_set_text(".feelslike", belchertown_label_text("$obs.label.feels_like") + " " + parseFloat(parseFloat(data["appTemp_F"])).toLocaleString("$system_locale_js", {minimumFractionDigits: unit_rounding_array["outTemp"], maximumFractionDigits: unit_rounding_array["outTemp"]}) + " " + belchertown_label_text("$unit.label.outTemp"));
     }
 
     // Apparent Temperature Metric
     if (data.hasOwnProperty("appTemp_C")) {
-        jQuery(".feelslike").text(belchertown_label_text("$obs.label.feels_like") + " " + parseFloat(parseFloat(data["appTemp_C"])).toLocaleString("$system_locale_js", {minimumFractionDigits: unit_rounding_array["outTemp"], maximumFractionDigits: unit_rounding_array["outTemp"]}) + " " + belchertown_label_text("$unit.label.outTemp"));
+        mqtt_set_text(".feelslike", belchertown_label_text("$obs.label.feels_like") + " " + parseFloat(parseFloat(data["appTemp_C"])).toLocaleString("$system_locale_js", {minimumFractionDigits: unit_rounding_array["outTemp"], maximumFractionDigits: unit_rounding_array["outTemp"]}) + " " + belchertown_label_text("$unit.label.outTemp"));
     }
 
     // Wind
     if (data.hasOwnProperty("windDir")) {
         rotateThis(data["windDir"]);
-        jQuery(".curwinddeg").html(parseFloat(data["windDir"]).toFixed(0) + "&deg;");
-        jQuery(".curwinddir").html(highcharts_tooltip_factory(parseFloat(data["windDir"]).toFixed(0), "windDir"));
+        mqtt_set_html(".curwinddeg", parseFloat(data["windDir"]).toFixed(0) + "&deg;");
+        mqtt_set_html(".curwinddir", highcharts_tooltip_factory(parseFloat(data["windDir"]).toFixed(0), "windDir"));
     }
 
     if (data.hasOwnProperty("windSpeed_mph")) {
-        jQuery(".curwindspeed").html(parseFloat(parseFloat(data["windSpeed_mph"])).toLocaleString("$system_locale_js", {minimumFractionDigits: unit_rounding_array["windSpeed"], maximumFractionDigits: unit_rounding_array["windSpeed"]}));
-        jQuery(".beaufort").html(beaufort_cat(kts_to_beaufort(parseFloat(data["windGust_mph"]) * 0.8689758)));
+        mqtt_set_html(".curwindspeed", parseFloat(parseFloat(data["windSpeed_mph"])).toLocaleString("$system_locale_js", {minimumFractionDigits: unit_rounding_array["windSpeed"], maximumFractionDigits: unit_rounding_array["windSpeed"]}));
+        mqtt_set_html(".beaufort", beaufort_cat(kts_to_beaufort(parseFloat(data["windGust_mph"]) * 0.8689758)));
     }
     if (data.hasOwnProperty("windSpeed_kph")) {
-        jQuery(".curwindspeed").html(parseFloat(parseFloat(data["windSpeed_kph"])).toLocaleString("$system_locale_js", {minimumFractionDigits: unit_rounding_array["windSpeed"], maximumFractionDigits: unit_rounding_array["windSpeed"]}));
-        jQuery(".beaufort").html(beaufort_cat(kts_to_beaufort(parseFloat(data["windGust_kph"]) * 0.5399565)));
+        mqtt_set_html(".curwindspeed", parseFloat(parseFloat(data["windSpeed_kph"])).toLocaleString("$system_locale_js", {minimumFractionDigits: unit_rounding_array["windSpeed"], maximumFractionDigits: unit_rounding_array["windSpeed"]}));
+        mqtt_set_html(".beaufort", beaufort_cat(kts_to_beaufort(parseFloat(data["windGust_kph"]) * 0.5399565)));
     }
     if (data.hasOwnProperty("windSpeed_mps")) {
-        jQuery(".curwindspeed").html(parseFloat(parseFloat(data["windSpeed_mps"])).toLocaleString("$system_locale_js", {minimumFractionDigits: unit_rounding_array["windSpeed"], maximumFractionDigits: unit_rounding_array["windSpeed"]}));
-        jQuery(".beaufort").html(beaufort_cat(kts_to_beaufort(parseFloat(data["windGust_mps"]) * 1.943844)));
+        mqtt_set_html(".curwindspeed", parseFloat(parseFloat(data["windSpeed_mps"])).toLocaleString("$system_locale_js", {minimumFractionDigits: unit_rounding_array["windSpeed"], maximumFractionDigits: unit_rounding_array["windSpeed"]}));
+        mqtt_set_html(".beaufort", beaufort_cat(kts_to_beaufort(parseFloat(data["windGust_mps"]) * 1.943844)));
     }
     if (data.hasOwnProperty("windSpeed_beaufort")) {
-        jQuery(".curwindspeed").html(parseFloat(parseFloat(data["windSpeed_beaufort"])).toLocaleString("$system_locale_js", {minimumFractionDigits: unit_rounding_array["windSpeed"], maximumFractionDigits: unit_rounding_array["windSpeed"]}));
-        jQuery(".beaufort").html(beaufort_cat(parseFloat(data["windGust_beaufort"])));
+        mqtt_set_html(".curwindspeed", parseFloat(parseFloat(data["windSpeed_beaufort"])).toLocaleString("$system_locale_js", {minimumFractionDigits: unit_rounding_array["windSpeed"], maximumFractionDigits: unit_rounding_array["windSpeed"]}));
+        mqtt_set_html(".beaufort", beaufort_cat(parseFloat(data["windGust_beaufort"])));
     }
     if (data.hasOwnProperty("windSpeed_knot")) {
-        jQuery(".curwindspeed").html(parseFloat(parseFloat(data["windSpeed_knot"])).toLocaleString("$system_locale_js", {minimumFractionDigits: unit_rounding_array["windSpeed"], maximumFractionDigits: unit_rounding_array["windSpeed"]}));
-        jQuery(".beaufort").html(beaufort_cat(kts_to_beaufort(parseFloat(data["windGust_knot"]))));
+        mqtt_set_html(".curwindspeed", parseFloat(parseFloat(data["windSpeed_knot"])).toLocaleString("$system_locale_js", {minimumFractionDigits: unit_rounding_array["windSpeed"], maximumFractionDigits: unit_rounding_array["windSpeed"]}));
+        mqtt_set_html(".beaufort", beaufort_cat(kts_to_beaufort(parseFloat(data["windGust_knot"]))));
     }
 
     if (data.hasOwnProperty("beaufort")) {
-        jQuery(".beaufort").html(beaufort_cat(parseFloat(data["beaufort"])));
+        mqtt_set_html(".beaufort", beaufort_cat(parseFloat(data["beaufort"])));
     }
 
     if (data.hasOwnProperty("windGust_mph")) {
-        jQuery(".curwindgust").html(parseFloat(parseFloat(data["windGust_mph"])).toLocaleString("$system_locale_js", {minimumFractionDigits: unit_rounding_array["windGust"], maximumFractionDigits: unit_rounding_array["windGust"]}));
+        mqtt_set_html(".curwindgust", parseFloat(parseFloat(data["windGust_mph"])).toLocaleString("$system_locale_js", {minimumFractionDigits: unit_rounding_array["windGust"], maximumFractionDigits: unit_rounding_array["windGust"]}));
     }
     if (data.hasOwnProperty("windGust_kph")) {
-        jQuery(".curwindgust").html(parseFloat(parseFloat(data["windGust_kph"])).toLocaleString("$system_locale_js", {minimumFractionDigits: unit_rounding_array["windGust"], maximumFractionDigits: unit_rounding_array["windGust"]}));
+        mqtt_set_html(".curwindgust", parseFloat(parseFloat(data["windGust_kph"])).toLocaleString("$system_locale_js", {minimumFractionDigits: unit_rounding_array["windGust"], maximumFractionDigits: unit_rounding_array["windGust"]}));
     }
     if (data.hasOwnProperty("windGust_mps")) {
-        jQuery(".curwindgust").html(parseFloat(parseFloat(data["windGust_mps"])).toLocaleString("$system_locale_js", {minimumFractionDigits: unit_rounding_array["windGust"], maximumFractionDigits: unit_rounding_array["windGust"]}));
+        mqtt_set_html(".curwindgust", parseFloat(parseFloat(data["windGust_mps"])).toLocaleString("$system_locale_js", {minimumFractionDigits: unit_rounding_array["windGust"], maximumFractionDigits: unit_rounding_array["windGust"]}));
     }
     if (data.hasOwnProperty("windGust_beaufort")) {
-        jQuery(".curwindgust").html(parseFloat(parseFloat(data["windGust_beaufort"])).toLocaleString("$system_locale_js", {minimumFractionDigits: unit_rounding_array["windSpeed"], maximumFractionDigits: unit_rounding_array["windSpeed"]}));
+        mqtt_set_html(".curwindgust", parseFloat(parseFloat(data["windGust_beaufort"])).toLocaleString("$system_locale_js", {minimumFractionDigits: unit_rounding_array["windSpeed"], maximumFractionDigits: unit_rounding_array["windSpeed"]}));
     }
     if (data.hasOwnProperty("windGust_knot")) {
-        jQuery(".curwindgust").html(parseFloat(parseFloat(data["windGust_knot"])).toLocaleString("$system_locale_js", {minimumFractionDigits: unit_rounding_array["windSpeed"], maximumFractionDigits: unit_rounding_array["windSpeed"]}));
+        mqtt_set_html(".curwindgust", parseFloat(parseFloat(data["windGust_knot"])).toLocaleString("$system_locale_js", {minimumFractionDigits: unit_rounding_array["windSpeed"], maximumFractionDigits: unit_rounding_array["windSpeed"]}));
     }
 
     if (data.hasOwnProperty("windchill")) {
-        jQuery(".curwindchill").text(parseFloat(parseFloat(data["windchill"])).toLocaleString("$system_locale_js", {minimumFractionDigits: unit_rounding_array["windchill"], maximumFractionDigits: unit_rounding_array["windchill"]}) + belchertown_label_text("$unit.label.outTemp"));
+        mqtt_set_text(".curwindchill", parseFloat(parseFloat(data["windchill"])).toLocaleString("$system_locale_js", {minimumFractionDigits: unit_rounding_array["windchill"], maximumFractionDigits: unit_rounding_array["windchill"]}) + belchertown_label_text("$unit.label.outTemp"));
     }
     if (data.hasOwnProperty("windchill_C")) {
-        jQuery(".curwindchill").text(parseFloat(parseFloat(data["windchill_C"])).toLocaleString("$system_locale_js", {minimumFractionDigits: unit_rounding_array["windchill"], maximumFractionDigits: unit_rounding_array["windchill"]}) + belchertown_label_text("$unit.label.outTemp"));
+        mqtt_set_text(".curwindchill", parseFloat(parseFloat(data["windchill_C"])).toLocaleString("$system_locale_js", {minimumFractionDigits: unit_rounding_array["windchill"], maximumFractionDigits: unit_rounding_array["windchill"]}) + belchertown_label_text("$unit.label.outTemp"));
     }
     mqtt_render_status_modal();
 };


### PR DESCRIPTION
Part 3 of the jQuery-removal series (see #237 for the full plan).

Converts `new-belchertown-mqtt.js.tmpl` to vanilla JS:
- live observation writers go through small `mqtt_set_html`/`mqtt_set_text` helpers that **skip `undefined` values** — this matters: `jQuery.html(undefined)` silently no-ops (getter mode), while `innerHTML = undefined` renders the literal string "undefined". We hit this for real during testing, so the helpers encode jQuery's behaviour
- connection status markers toggle inline `display`; the cached marker/observation lookups keep their NodeLists
- the connection-details modal uses `bootstrap.Modal.getOrCreateInstance`, delegated clicks use `closest()`
- `jQuery.parseJSON` becomes `JSON.parse`; the almanac diagram live updates use plain dataset/attribute access

No behaviour change; jQuery stays loaded until the final PR in the series.

Tested on a live weewx 5.1 station with real broker traffic, plus a synthetic packet driven through `onMessageArrived` to exercise every writer path: live values, status markers, relative updated text, the details modal (all packet rows) and the disconnect/reconnect/restart flow behave as before.

Stacked on #238 — the MQTT changes are the head commit only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)