### PR TITLE
Convert inline template scripts to vanilla JS and drop jQuery

### DIFF
--- a/skins/new-belchertown/charts/index.html.tmpl
+++ b/skins/new-belchertown/charts/index.html.tmpl
@@ -36,14 +36,17 @@
                     }
                 }
 
-                jQuery(document).ready(function() {
+                belchertown_on_ready(function() {
                     if (chart == "all") {
                         // Build all chart sections first, then lazy-render by visibility.
                         var i = 0;
                         var chartGroupEntries = [];
 
                         // Rename the chart-outer div to remove CSS
-                        jQuery(".chart-outer").attr("class", "chart-outer-all");
+                        var chartOuter = document.querySelector(".chart-outer");
+                        if (chartOuter) {
+                            chartOuter.setAttribute("class", "chart-outer-all");
+                        }
 
                         for (var chartgroup in chartgroups_raw) {
                             var page_content = "";
@@ -52,7 +55,8 @@
                             }
 
                             // Loop through every chart group defined and add a title section
-                            jQuery(".chart-outer-all").append('\
+                            if (chartOuter) {
+                                chartOuter.insertAdjacentHTML("beforeend", '\
                                     <div class="' + chartgroup + '_outer row" style="margin:25px 0px 25px 0px;clear:both;">\
                                         <div class="chartpage-title wx-buttons-description">\
                                             <a href="./?chart='+ chartgroup + '">' + chartgroups_titles[chartgroup] + '</a>\
@@ -61,19 +65,24 @@
                                         <div class="' + chartgroup + '"></div>\
                                     </div>\
                                 ');
+                            }
 
-                            if (i > 0) {
-                                jQuery("." + chartgroup + "_outer").css("border-top", "1px solid #ccc");
+                            var groupOuter = document.querySelector("." + chartgroup + "_outer");
+                            if (i > 0 && groupOuter) {
+                                groupOuter.style.borderTop = "1px solid #ccc";
                             }
 
                             // Within each title section add the chart divs with the chart group prepending to avoid conflicts
+                            var groupDiv = document.querySelector("." + chartgroup);
                             chartgroups_raw[chartgroup].forEach(chartID => {
-                                jQuery("." + chartgroup).append('<div class="col-md-6"><div id="' + chartgroup + "_" + chartID + '" style="width:100%;height:100%;margin-top:20px;"></div></div>');
+                                if (groupDiv) {
+                                    groupDiv.insertAdjacentHTML("beforeend", '<div class="col-md-6"><div id="' + chartgroup + "_" + chartID + '" style="width:100%;height:100%;margin-top:20px;"></div></div>');
+                                }
                             });
 
                             chartGroupEntries.push({
                                 chartgroup: chartgroup,
-                                element: jQuery("." + chartgroup + "_outer").get(0),
+                                element: groupOuter,
                             });
 
                             i++;
@@ -104,15 +113,18 @@
                     } else {
                         // Loop through the chart group for this page and add the chart divs to the page
                         try {
+                            var singleChartOuter = document.querySelector(".chart-outer");
                             thisPageCharts.forEach(chartID => {
-                                jQuery(".chart-outer").append('<div class="col-md-12"><div id="' + chartID + '" style="width:100%;height:100%;margin-top:20px;"></div></div>');
+                                if (singleChartOuter) {
+                                    singleChartOuter.insertAdjacentHTML("beforeend", '<div class="col-md-12"><div id="' + chartID + '" style="width:100%;height:100%;margin-top:20px;"></div></div>');
+                                }
                             });
 
                             // Set page title
-                            jQuery(".chartpage-title").html(chartgroups_titles[chart]);
+                            belchertown_set_html(".chartpage-title", chartgroups_titles[chart]);
 
                             // Set page content
-                            jQuery(".chartpage-content").html(chartpage_content[chart]);
+                            belchertown_set_html(".chartpage-content", chartpage_content[chart]);
 
                             // Render when the chart area is near viewport.
                             belchertown_run_when_visible(".chart-outer", function() {

--- a/skins/new-belchertown/header.html.tmpl
+++ b/skins/new-belchertown/header.html.tmpl
@@ -170,7 +170,6 @@
         <link rel="apple-touch-icon" sizes="192x192" href="$relative_url/images/station192.png">
         
         #if $load_core_js
-        <script defer type='text/javascript' src="//ajax.googleapis.com/ajax/libs/jquery/3.7.1/jquery.min.js"></script>
         <script defer type='text/javascript' src="//cdnjs.cloudflare.com/ajax/libs/moment.js/2.24.0/moment-with-locales.min.js"></script>
         #if $moment_js_tz and str($moment_js_tz).strip() != ""
         <script defer type='text/javascript' src="https://cdnjs.cloudflare.com/ajax/libs/moment-timezone/0.5.33/moment-timezone-with-data.min.js"></script>

--- a/skins/new-belchertown/index.html.tmpl
+++ b/skins/new-belchertown/index.html.tmpl
@@ -70,15 +70,15 @@
         setTimeout(autoRefreshPage, $Extras.webpage_autorefresh);
         // #end if
 
-        jQuery(document).ready(function() {
+        belchertown_on_ready(function() {
             // #if $Extras.has_key("aqi_enabled") and $Extras.aqi_enabled == '1'
             get_aqi_color("$aqi");
             // #end if
 
             // #if $Extras.has_key("beaufort_category") and $Extras.beaufort_category == '1' and $Extras.beaufort_category_gusts != '1'
-            jQuery(".beaufort").html(beaufort_cat(kts_to_beaufort("$current.windSpeed.knot.toString(addLabel=False)")));
+            belchertown_set_html(".beaufort", beaufort_cat(kts_to_beaufort("$current.windSpeed.knot.toString(addLabel=False)")));
             // #else
-            jQuery(".beaufort").html(beaufort_cat(kts_to_beaufort("$current.windGust.knot.toString(addLabel=False)")));
+            belchertown_set_html(".beaufort", beaufort_cat(kts_to_beaufort("$current.windGust.knot.toString(addLabel=False)")));
             // #end if
 
             get_outTemp_color("$unit.unit_type.outTemp", "$current.outTemp.formatted");
@@ -92,14 +92,14 @@
             // Update the Last Updated timestamp with moment.js,
             updated = tzAdjustedMoment($current.dateTime.raw).format(belchertown_label_text("$obs.label.time_last_updated"));
             updated_text = belchertown_label_text("$obs.label.header_last_updated") + " " + updated;
-            jQuery(".updated").text(updated_text);
+            belchertown_set_text(".updated", updated_text);
 
             // #if $Extras.has_key('earthquake_enabled') and $Extras.earthquake_enabled == '1'            
             if (moment.unix("$earthquake_time").isValid()) {
                 // Check that the time is the time (number) and not the "no earthquake available" wording
-                jQuery(".earthquake-time").text(tzAdjustedMoment("$earthquake_time").format(belchertown_label_text("$obs.label.time_earthquake")));
+                belchertown_set_text(".earthquake-time", tzAdjustedMoment("$earthquake_time").format(belchertown_label_text("$obs.label.time_earthquake")));
             } else {
-                jQuery(".earthquake-time").text(belchertown_label_text("$earthquake_time"));
+                belchertown_set_text(".earthquake-time", belchertown_label_text("$earthquake_time"));
             }
             // #end if
 
@@ -109,7 +109,7 @@
             // Loop through the chart groups for this page and add the chart divs to the page
             try {
                 thisPageCharts.forEach(chartID => {
-                    jQuery(".chart-outer").append('<div class="homepage-chart-panel"><div id="' + chartID + '" style="width:100%;height:100%;"></div></div>');
+                    document.querySelectorAll(".chart-outer").forEach(function(el) { el.insertAdjacentHTML("beforeend", '<div class="homepage-chart-panel"><div id="' + chartID + '" style="width:100%;height:100%;"></div></div>'); });
                 });
 
                 belchertown_run_when_visible(".homepage-card--charts", function() {
@@ -169,15 +169,15 @@
             if ((Math.floor(new Date().getTime() / 1000.0) - $Extras.last_updated_alert_threshold) > $current.dateTime.raw) {
                 belchertown_debug("Last Updated Alert: The WeeWX report timestamp is " + $current.dateTime.raw + ". The current timestamp is " + Math.floor(new Date().getTime() / 1000.0) + ". The threshold is " + $Extras.last_updated_alert_threshold + ". Report timestamp is greater than threshold of current time, showing no update alert.");
                 last_updated_alert_text = "<i class='fa fa-exclamation-triangle' style='color:red;'></i> " + belchertown_label_html("$obs.label.header_last_updated_alert");
-                jQuery(".last-updated-alert").html(last_updated_alert_text);
-                jQuery(".last-updated-alert").show();
+                belchertown_set_html(".last-updated-alert", last_updated_alert_text);
+                document.querySelectorAll(".last-updated-alert").forEach(function(el) { el.style.display = ""; });
             }
             // #end if
 
             // Update the Last Updated timestamp with moment.js,
             updated = tzAdjustedMoment($current.dateTime.raw).format(belchertown_label_text("$obs.label.time_last_updated"));
             updated_text = belchertown_label_text("$obs.label.header_last_updated") + " " + updated;
-            jQuery(".updated").text(updated_text);
+            belchertown_set_text(".updated", updated_text);
 
             // #end if
 

--- a/skins/new-belchertown/js/new-belchertown-charts.js.tmpl
+++ b/skins/new-belchertown/js/new-belchertown-charts.js.tmpl
@@ -319,9 +319,10 @@ function belchertown_detect_highcharts_modules(chartData) {
         return modules;
     }
 
-    jQuery.each(chartData, function(plotname, plotData) {
+    Object.keys(chartData).forEach(function(plotname) {
+        var plotData = chartData[plotname];
         if (!plotData || typeof plotData !== "object" || !plotData.options) {
-            return true;
+            return;
         }
 
         if (plotData.options.type === "gauge") {
@@ -335,15 +336,13 @@ function belchertown_detect_highcharts_modules(chartData) {
         }
 
         if (plotData.series && typeof plotData.series === "object") {
-            jQuery.each(plotData.series, function(seriesName, seriesData) {
+            Object.keys(plotData.series).forEach(function(seriesName) {
+                var seriesData = plotData.series[seriesName];
                 if (seriesData && seriesData.obsType === "windBarb") {
                     modules.add("windbarb");
                 }
-                return true;
             });
         }
-
-        return true;
     });
 
     return modules;
@@ -563,16 +562,18 @@ function showChart(json_file, prepend_renderTo = false) {
     });
 
     // Relative URL by finding what page we're on currently.
-    jQuery.ajax({
-        url: get_relative_url() + '/json/' + json_file + '.json',
-        dataType: 'json',
-        headers: {'Cache-Control': 'no-cache'},
-    }).done(function(data) {
+    fetch(get_relative_url() + '/json/' + json_file + '.json', {cache: "no-cache"}).then(function(resp) {
+        if (!resp.ok) {
+            throw new Error("HTTP error! Unable to load " + json_file + ".json");
+        }
+        return resp.json();
+    }).then(function(data) {
 
         var renderCharts = function() {
 
         // Loop through each chart name (e.g. chart1, chart2, chart3)
-        jQuery.each(data, function(plotname, obsname) {
+        Object.keys(data).forEach(function(plotname) {
+            var obsname = data[plotname];
             var observation_type = undefined;
             xAxis_categories = [];
             plot_tooltip_date_format = undefined;
@@ -583,51 +584,52 @@ function showChart(json_file, prepend_renderTo = false) {
 
             // Ignore the New Belchertown Version since this "plot" has no other options
             if (plotname == "belchertown_version") {
-                return true;
+                return;
             }
 
             // Ignore the generated timestamp since this "plot" has no other options
             if (plotname == "generated_timestamp") {
-                return true;
+                return;
             }
 
             // Ignore the chartgroup_title since this "plot" has no other options
             if (plotname == "chartgroup_title") {
-                return true;
+                return;
             }
 
             // Set the chart's tooltip date time format, then return since this "plot" has no other options
             if (plotname == "tooltip_date_format") {
                 tooltip_date_format = obsname;
-                return true;
+                return;
             }
 
             // Set the chart colors, then return right away since this "plot" has no other options
             if (plotname == "colors") {
                 colors = obsname.split(",");
-                return true;
+                return;
             }
 
             // Set the chart credits, then return right away since this "plot" has no other options
             if (plotname == "credits") {
                 credits = obsname.split(",")[0];
-                return true;
+                return;
             }
 
             // Set the chart credits url, then return right away since this "plot" has no other options
             if (plotname == "credits_url") {
                 credits_url = obsname.split(",")[0];
-                return true;
+                return;
             }
 
             // Set the chart credits position, then return right away since this "plot" has no other options
             if (plotname == "credits_position") {
                 credits_position = obsname;
-                return true;
+                return;
             }
 
             // Loop through each chart options
-            jQuery.each(data[plotname]["options"], function(optionName, optionVal) {
+            Object.keys(data[plotname]["options"]).forEach(function(optionName) {
+                var optionVal = data[plotname]["options"][optionName];
                 switch (optionName) {
                     case "type":
                         type = optionVal;
@@ -736,7 +738,10 @@ function showChart(json_file, prepend_renderTo = false) {
 
                                         this.subtitle.update({style: {color: darktheme_textcolor}});
 
-                                        this.chartBackground.attr({fill: jQuery(".highcharts-background").css("fill")});
+                                        var hcBackground = document.querySelector(".highcharts-background");
+                                        if (hcBackground) {
+                                            this.chartBackground.attr({fill: getComputedStyle(hcBackground).fill});
+                                        }
                                     } else {
                                         var lighttheme_textcolor = '#666666';
                                         for (var i = this.yAxis.length - 1; i >= 0; i--) {
@@ -932,7 +937,14 @@ function showChart(json_file, prepend_renderTo = false) {
             belchertown_debug(options.chart.renderTo + ": building a " + type + " chart");
 
             if (css_class) {
-                jQuery("#" + options.chart.renderTo).addClass(css_class);
+                var chartDiv = document.getElementById(options.chart.renderTo);
+                if (chartDiv) {
+                    css_class.split(/\s+/).forEach(function(cls) {
+                        if (cls) {
+                            chartDiv.classList.add(cls);
+                        }
+                    });
+                }
                 belchertown_debug(options.chart.renderTo + ": div id is " + options.chart.renderTo + " and adding CSS class: " + css_class);
             }
 
@@ -981,7 +993,7 @@ function showChart(json_file, prepend_renderTo = false) {
 
             // Build the series
             var i = 0;
-            jQuery.each(data[plotname]["series"], function(seriesName, seriesVal) {
+            Object.keys(data[plotname]["series"]).forEach(function(seriesName) {
                 observation_type = data[plotname]["series"][seriesName]["obsType"];
                 options.series[i] = data[plotname]["series"][seriesName];
                 i++;
@@ -1619,15 +1631,15 @@ function showChart(json_file, prepend_renderTo = false) {
             }
 
             // Apply any width, height CSS overrides to the parent div of the chart
-            if (css_height != "") {
-                jQuery("#" + options.chart.renderTo).parent().css({
-                    'height': css_height,
-                    'padding': '0px 15px',
-                    'margin-bottom': '20px'
-                });
+            var chartParent = document.getElementById(options.chart.renderTo);
+            chartParent = chartParent ? chartParent.parentElement : null;
+            if (css_height != "" && chartParent) {
+                chartParent.style.height = css_height;
+                chartParent.style.padding = '0px 15px';
+                chartParent.style.marginBottom = '20px';
             }
-            if (css_width != "") {
-                jQuery("#" + options.chart.renderTo).parent().css('width', css_width);
+            if (css_width != "" && chartParent) {
+                chartParent.style.width = css_width;
             }
 
             if (credits != "highcharts_default") {
@@ -1800,10 +1812,10 @@ function showChart(json_file, prepend_renderTo = false) {
                 // Add a visible placeholder for the skipped chart so users
                 // know why this chart is empty.
                 if (typeof options !== "undefined" && options.chart && options.chart.renderTo) {
-                    var failedChart = jQuery("#" + options.chart.renderTo);
-                    if (failedChart.length) {
+                    var failedChart = document.getElementById(options.chart.renderTo);
+                    if (failedChart) {
                         var unavailableObs = observation_type || plotname || belchertown_label_text("$obs.label.unknown_observation");
-                        failedChart.html(
+                        failedChart.innerHTML = (
                             '<div class="chart-unavailable" style="padding:14px 10px;text-align:center;color:#888;">' +
                             '<div>' + belchertown_label_html("$obs.label.chart_unavailable") + ' (' + belchertown_label_html("$obs.label.chart_unavailable_detail") + ')</div>' +
                             '<div style="margin-top:6px;font-weight:500;">' + belchertown_label_html("$obs.label.observation") + ': ' + belchertown_escape_html(unavailableObs) + '</div>' +
@@ -1812,7 +1824,7 @@ function showChart(json_file, prepend_renderTo = false) {
                     }
                 }
 
-                return true;
+                return;
             }
 
         });
@@ -1839,6 +1851,8 @@ function showChart(json_file, prepend_renderTo = false) {
             renderCharts();
         });
 
+    }).catch(function(err) {
+        belchertown_debug("Chart data load error: " + err.message + ". Skipping chart render.");
     });
 
 };

--- a/skins/new-belchertown/js/new-belchertown-forecast.js.tmpl
+++ b/skins/new-belchertown/js/new-belchertown-forecast.js.tmpl
@@ -42,7 +42,7 @@ function ajaxforecast() {
     forecast_start_refresh_timer();
 
     if (forecast_refresh_in_progress) {
-        return jQuery.Deferred().resolve().promise();
+        return Promise.resolve();
     }
 
     forecast_refresh_in_progress = true;
@@ -50,39 +50,39 @@ function ajaxforecast() {
     forecast_data = {};
     current_conditions_data = {};
 
-    const pCurrent = jQuery
-        .ajax({
-            url: forecast_json_url("current_conditions.json"),
-            dataType: "json",
-            cache: false,
-            headers: {"Cache-Control": "no-cache, no-store"},
+    const pCurrent = fetch(forecast_json_url("current_conditions.json"), {cache: "no-store"})
+        .then(function(resp) {
+            if (!resp.ok) {
+                throw new Error("HTTP error! Unable to load current_conditions.json");
+            }
+            return resp.json();
         })
-        .done(function(current_conditions) {
+        .then(function(current_conditions) {
             current_conditions_data = current_conditions;
         });
 
-    const pForecast = jQuery
-        .ajax({
-            url: forecast_json_url("forecast.json"),
-            dataType: "json",
-            cache: false,
-            headers: {"Cache-Control": "no-cache, no-store"},
+    const pForecast = fetch(forecast_json_url("forecast.json"), {cache: "no-store"})
+        .then(function(resp) {
+            if (!resp.ok) {
+                throw new Error("HTTP error! Unable to load forecast.json");
+            }
+            return resp.json();
         })
-        .done(function(forecast) {
+        .then(function(forecast) {
             forecast_data = forecast;
         });
 
     const promises = [pCurrent, pForecast];
 
-    return jQuery.when.apply(jQuery, promises)
+    return Promise.all(promises)
         .then(function() {
             update_current_conditions(current_conditions_data, forecast_data);
             update_forecast_data(forecast_data);
         })
-        .fail(function(err) {
+        .catch(function(err) {
             console.error("Forecast fetch failed:", err);
         })
-        .always(function() {
+        .finally(function() {
             forecast_refresh_in_progress = false;
         });
 }
@@ -272,9 +272,12 @@ function forecast_payload_source(data, fallbackProvider) {
 
 function forecast_render_source(data) {
     const source = forecast_payload_source(data, "");
-    jQuery(".forecast-source")
-        .text(forecast_sentence_text([forecast_label_text("$obs.label.source") + ": " + source]))
-        .attr("title", forecast_label_text("$obs.label.forecast_source") + ": " + source);
+    const sourceText = forecast_sentence_text([forecast_label_text("$obs.label.source") + ": " + source]);
+    const sourceTitle = forecast_label_text("$obs.label.forecast_source") + ": " + source;
+    document.querySelectorAll(".forecast-source").forEach(function(el) {
+        el.textContent = sourceText;
+        el.setAttribute("title", sourceTitle);
+    });
 }
 
 function forecast_current_observation_epoch(data) {
@@ -283,9 +286,15 @@ function forecast_current_observation_epoch(data) {
 }
 
 function forecast_observation_label(row, fallback) {
-    const labelCell = row.find(".station-observations-label").first().clone();
-    labelCell.find(".observation-source-info").remove();
-    return jQuery.trim(labelCell.text()) || fallback;
+    const labelCell = row.querySelector(".station-observations-label");
+    if (!labelCell) {
+        return fallback;
+    }
+    const clone = labelCell.cloneNode(true);
+    clone.querySelectorAll(".observation-source-info").forEach(function(el) {
+        el.remove();
+    });
+    return clone.textContent.trim() || fallback;
 }
 
 function forecast_observation_age_sentence(epoch) {
@@ -298,7 +307,7 @@ function forecast_observation_age_sentence(epoch) {
 }
 
 function forecast_ensure_observation_modal() {
-    if (jQuery("#observation-source-modal").length) {
+    if (document.getElementById("observation-source-modal")) {
         return;
     }
 
@@ -317,7 +326,7 @@ function forecast_ensure_observation_modal() {
     modal += "</div>";
     modal += "</div>";
     modal += "</div>";
-    jQuery("body").append(modal);
+    document.body.insertAdjacentHTML("beforeend", modal);
 }
 
 function forecast_render_observation_modal(observationKey) {
@@ -335,10 +344,14 @@ function forecast_render_observation_modal(observationKey) {
         body += "<p class='observation-source-modal-time'>" + forecast_escape_html(observedAt) + "</p>";
     }
 
-    jQuery("#observation-source-modal")
-        .data("observation", observationKey)
-        .find(".observation-source-modal-body")
-        .html(body);
+    const modal = document.getElementById("observation-source-modal");
+    if (modal) {
+        modal.dataset.observation = observationKey;
+        const modalBody = modal.querySelector(".observation-source-modal-body");
+        if (modalBody) {
+            modalBody.innerHTML = body;
+        }
+    }
 }
 
 function forecast_bind_observation_info() {
@@ -347,23 +360,29 @@ function forecast_bind_observation_info() {
     }
 
     forecast_observation_info_bound = true;
-    jQuery(document).on("click", ".observation-source-info", function(event) {
+    document.addEventListener("click", function(event) {
+        const trigger = event.target.closest(".observation-source-info");
+        if (!trigger) {
+            return;
+        }
         event.preventDefault();
         forecast_ensure_observation_modal();
-        forecast_render_observation_modal(jQuery(this).data("observation"));
-        jQuery("#observation-source-modal").modal("show");
+        forecast_render_observation_modal(trigger.dataset.observation);
+        bootstrap.Modal.getOrCreateInstance(document.getElementById("observation-source-modal")).show();
     });
 }
 
 function forecast_register_external_observation(observationKey, data, options) {
     options = options || {};
-    let row = jQuery(".station-observations tr").filter(function() {
-        return jQuery(this).data("observation") === observationKey;
-    }).first();
-    if (!row.length) {
-        row = jQuery(".station-observations ." + observationKey).closest("tr");
+    let row = Array.prototype.find.call(
+        document.querySelectorAll(".station-observations tr"),
+        function(tr) { return tr.dataset.observation === observationKey; }
+    ) || null;
+    if (!row) {
+        const obsCell = document.querySelector(".station-observations ." + observationKey);
+        row = obsCell ? obsCell.closest("tr") : null;
     }
-    if (!row.length) {
+    if (!row) {
         return;
     }
 
@@ -382,26 +401,31 @@ function forecast_register_external_observation(observationKey, data, options) {
         epoch: observationEpoch
     };
 
-    row.addClass("station-observation-row station-observation-row--external");
+    row.classList.add("station-observation-row", "station-observation-row--external");
 
-    let button = row.find(".observation-source-info").first();
-    if (!button.length) {
-        button = jQuery("<button type='button' class='observation-source-info'><i class='fa fa-info' aria-hidden='true'></i></button>");
-        row.find(".station-observations-label").first().append(button);
+    let button = row.querySelector(".observation-source-info");
+    if (!button) {
+        button = document.createElement("button");
+        button.type = "button";
+        button.className = "observation-source-info";
+        button.innerHTML = "<i class='fa fa-info' aria-hidden='true'></i>";
+        const labelCell = row.querySelector(".station-observations-label");
+        if (labelCell) {
+            labelCell.appendChild(button);
+        }
     }
 
-    button
-        .data("observation", observationKey)
-        .attr("aria-label", forecast_template_text("$obs.label.observation_source_information", [label]))
-        .attr("title", forecast_template_text("$obs.label.observation_source_information", [label]));
+    button.dataset.observation = observationKey;
+    button.setAttribute("aria-label", forecast_template_text("$obs.label.observation_source_information", [label]));
+    button.setAttribute("title", forecast_template_text("$obs.label.observation_source_information", [label]));
 
     forecast_bind_observation_info();
 }
 
 function forecast_register_external_observations(sourceKey, data, options) {
     const observationSources = forecast_station_observation_sources || {};
-    jQuery.each(observationSources, function(observationKey, metadata) {
-        metadata = metadata || {};
+    Object.keys(observationSources).forEach(function(observationKey) {
+        let metadata = observationSources[observationKey] || {};
         if (metadata["source_key"] !== sourceKey) {
             return;
         }
@@ -416,12 +440,16 @@ function forecast_register_external_observations(sourceKey, data, options) {
 function forecast_render_relative_timestamps() {
     if (forecast_last_updated_epoch !== null) {
         const forecastLabel = forecast_timestamp_label("$obs.label.forecast_last_updated");
-        jQuery(".forecast-subtitle")
-            .text(forecast_sentence_text([forecastLabel, forecast_relative_time(forecast_last_updated_epoch)]))
-            .attr("title", forecast_absolute_time(forecast_last_updated_epoch, '$obs.label.time_forecast_last_updated'));
+        const subtitleText = forecast_sentence_text([forecastLabel, forecast_relative_time(forecast_last_updated_epoch)]);
+        const subtitleTitle = forecast_absolute_time(forecast_last_updated_epoch, '$obs.label.time_forecast_last_updated');
+        document.querySelectorAll(".forecast-subtitle").forEach(function(el) {
+            el.textContent = subtitleText;
+            el.setAttribute("title", subtitleTitle);
+        });
     }
 
-    const activeObservation = jQuery("#observation-source-modal").data("observation");
+    const observationModal = document.getElementById("observation-source-modal");
+    const activeObservation = observationModal ? observationModal.dataset.observation : undefined;
     if (activeObservation) {
         forecast_render_observation_modal(activeObservation);
     }
@@ -517,11 +545,11 @@ function forecast_alert_in_effect_text(alertObj) {
 }
 
 function forecast_active_alert_modal() {
-    return jQuery(".modal.in[id^='forecast-alert-'], .modal.show[id^='forecast-alert-']").first();
+    return document.querySelector(".modal.in[id^='forecast-alert-'], .modal.show[id^='forecast-alert-']");
 }
 
 function forecast_alert_modal_by_id(id) {
-    return id ? jQuery(document.getElementById(id)) : jQuery();
+    return id ? document.getElementById(id) : null;
 }
 
 function forecast_alert_modal_html(forecastAlertId, forecastAlertTitleId, alertData) {
@@ -547,28 +575,31 @@ function forecast_alert_modal_html(forecastAlertId, forecastAlertTitleId, alertD
 }
 
 function forecast_update_alert_modal(modal, forecastAlertTitleId, alertData) {
-    modal
-        .addClass("forecast-alert-modal")
-        .attr("aria-labelledby", forecastAlertTitleId);
-    modal.find(".modal-title")
-        .attr("id", forecastAlertTitleId)
-        .html(forecast_escape_html(alertData["title"]));
-    modal.find(".modal-body").html(alertData["body"]);
+    modal.classList.add("forecast-alert-modal");
+    modal.setAttribute("aria-labelledby", forecastAlertTitleId);
+    var modalTitle = modal.querySelector(".modal-title");
+    if (modalTitle) {
+        modalTitle.id = forecastAlertTitleId;
+        modalTitle.innerHTML = forecast_escape_html(alertData["title"]);
+    }
+    var modalBody = modal.querySelector(".modal-body");
+    if (modalBody) {
+        modalBody.innerHTML = alertData["body"];
+    }
 }
 
 function forecast_remove_stale_alert_modals(currentAlertIds, activeAlertId) {
-    jQuery(".forecast-alert-modal, .modal[id^='forecast-alert-']").each(function() {
-        var modal = jQuery(this);
-        var modalId = modal.attr("id");
+    document.querySelectorAll(".forecast-alert-modal, .modal[id^='forecast-alert-']").forEach(function(modal) {
+        var modalId = modal.id;
 
         if (currentAlertIds[modalId]) {
             return;
         }
 
         if (modalId === activeAlertId) {
-            modal.one("hidden.bs.modal", function() {
-                jQuery(this).remove();
-            });
+            modal.addEventListener("hidden.bs.modal", function() {
+                modal.remove();
+            }, {once: true});
             return;
         }
 
@@ -581,17 +612,19 @@ function show_forcast_alert(data) {
     var i, forecast_alerts, forecast_alert_title, forecast_alert_body;
     var forecast_alert_link, forecast_alert_expires, forecast_alert_in_effect, alert_link;
     var activeAlertModal = forecast_active_alert_modal();
-    var activeAlertId = activeAlertModal.attr("id") || "";
+    var activeAlertId = (activeAlertModal && activeAlertModal.id) || "";
     var currentAlertIds = {};
-    var alertContainer = jQuery(".wx-stn-alert-text");
+    var alertContainer = document.querySelector(".wx-stn-alert-text");
     forecast_alerts = [];
 
-    if (activeAlertModal.length && activeAlertModal.closest(".wx-stn-alert-text").length) {
-        activeAlertModal.detach().appendTo("body");
+    if (activeAlertModal && activeAlertModal.closest(".wx-stn-alert-text")) {
+        document.body.appendChild(activeAlertModal);
     }
 
     // Empty the alert links from the previous run without removing any active modal node.
-    alertContainer.empty();
+    if (alertContainer) {
+        alertContainer.innerHTML = "";
+    }
 
     if (Array.isArray(data['alerts'])) {
         for (i = 0; i < data['alerts'].length; i++) {
@@ -629,19 +662,25 @@ function show_forcast_alert(data) {
 
             currentAlertIds[forecastAlertId] = true;
             alert_link = "<i class='fa fa-exclamation-triangle' aria-hidden='true'></i> <a href='#" + forecastAlertId + "' data-bs-toggle='modal' data-bs-target='#" + forecastAlertId + "'>" + forecast_escape_html(alertLinkText) + "</a><br>";
-            alertContainer.append(alert_link);
+            if (alertContainer) {
+                alertContainer.insertAdjacentHTML("beforeend", alert_link);
+            }
 
             var forecast_alert_modal = forecast_alert_modal_by_id(forecastAlertId);
-            if (forecast_alert_modal.length) {
+            if (forecast_alert_modal) {
                 forecast_update_alert_modal(forecast_alert_modal, forecastAlertTitleId, forecast_alerts[i]);
             } else {
-                jQuery("body").append(forecast_alert_modal_html(forecastAlertId, forecastAlertTitleId, forecast_alerts[i]));
+                document.body.insertAdjacentHTML("beforeend", forecast_alert_modal_html(forecastAlertId, forecastAlertTitleId, forecast_alerts[i]));
             }
         }
-        jQuery(".wx-stn-alert").show();
+        document.querySelectorAll(".wx-stn-alert").forEach(function(el) {
+            el.style.display = "block";
+        });
     } else {
         belchertown_debug("Forecast: There are no forecast alerts");
-        jQuery(".wx-stn-alert").hide();
+        document.querySelectorAll(".wx-stn-alert").forEach(function(el) {
+            el.style.display = "none";
+        });
     }
 
     forecast_remove_stale_alert_modals(currentAlertIds, activeAlertId);
@@ -698,14 +737,21 @@ function update_current_conditions(data, forecastData) {
             w34icon = resolveIconForProvider(fallbackPeriod["summary"], sourceProvider);
         }
         const wxicon = get_relative_url() + "/images/" + w34icon + ".png";
-        jQuery("#wxicon").attr("src", wxicon);
+        const wxiconEl = document.getElementById("wxicon");
+        if (wxiconEl) {
+            wxiconEl.src = wxicon;
+        }
 
         try {
-            jQuery(".current-obs-text").html(cc["summary"] || fallbackPeriod["summary"] || "");
+            document.querySelectorAll(".current-obs-text").forEach(function(el) {
+                el.innerHTML = cc["summary"] || fallbackPeriod["summary"] || "";
+            });
         } catch (err) { /* silent */}
 
         try {
-            jQuery(".station-observations .visibility").html(forecast_visibility_text(cc["visibility"], cc["visibilityQualifier"]));
+            document.querySelectorAll(".station-observations .visibility").forEach(function(el) {
+                el.innerHTML = forecast_visibility_text(cc["visibility"], cc["visibilityQualifier"]);
+            });
         } catch (err) { /* silent */}
 
         forecast_register_external_observations("current_conditions", data);
@@ -1002,8 +1048,7 @@ function forecast_render_daily_tiles(dailySource, maxTiles) {
 function forecast_fit_daily_condition_text() {
     const minFontSize = 11;
 
-    jQuery(".day_forecasts .forecast-day.forecast-tile").each(function() {
-        const tile = this;
+    document.querySelectorAll(".day_forecasts .forecast-day.forecast-tile").forEach(function(tile) {
         const conditions = tile.querySelector(".forecast-conditions");
         const text = tile.querySelector(".forecast-condition-text");
         if (!conditions || !text || conditions.offsetParent === null) {
@@ -1034,15 +1079,24 @@ function forecast_update_aqi(data) {
             const aqiPeriod = data["aqi"][0]["response"][0]["periods"][0];
             const aqiValue = aqiPeriod["aqi"];
             const aqiCategory = forecast_aqi_translate(aqiPeriod["category"]);
-            jQuery(".wx-aqi").text(aqiValue);
-            jQuery(".wx-aqi-category").text(aqiCategory);
+            document.querySelectorAll(".wx-aqi").forEach(function(el) {
+                el.textContent = aqiValue;
+            });
+            document.querySelectorAll(".wx-aqi-category").forEach(function(el) {
+                el.textContent = aqiCategory;
+            });
             get_aqi_color(aqiValue);
             if ("$Extras.aqi_location_enabled" === "1") {
                 const aqiPlace = data["aqi"][0]["response"][0]["place"]["name"] || "";
-                jQuery(".aqi_location_outer").html(aqiPlace ? "<br>" + aqiPlace : "").css('textTransform', 'capitalize');
+                document.querySelectorAll(".aqi_location_outer").forEach(function(el) {
+                    el.innerHTML = aqiPlace ? "<br>" + aqiPlace : "";
+                    el.style.textTransform = "capitalize";
+                });
             }
             try {
-                jQuery(".station-observations .aqi").text(aqiValue + " (" + aqiCategory + ")");
+                document.querySelectorAll(".station-observations .aqi").forEach(function(el) {
+                    el.textContent = aqiValue + " (" + aqiCategory + ")";
+                });
             } catch (err) {
                 // AQI not in the station observation table, so silently exit
             }
@@ -1052,12 +1106,22 @@ function forecast_update_aqi(data) {
             });
         } else if (data["aqi"] && data["aqi"][0] && data["aqi"][0]["success"] && data["aqi"][0]["error"] && data["aqi"][0]["error"]["code"] === "warn_no_data") {
             const aqiNoDataCategory = forecast_aqi_translate("");
-            jQuery(".wx-aqi").text(forecast_label_text("$obs.label.no_data"));
-            jQuery(".wx-aqi-category").text(aqiNoDataCategory);
+            document.querySelectorAll(".wx-aqi").forEach(function(el) {
+                el.textContent = forecast_label_text("$obs.label.no_data");
+            });
+            document.querySelectorAll(".wx-aqi-category").forEach(function(el) {
+                el.textContent = aqiNoDataCategory;
+            });
             clear_aqi_color();
-            if ("$Extras.aqi_location_enabled" === "1") jQuery(".aqi_location_outer").html("");
+            if ("$Extras.aqi_location_enabled" === "1") {
+                document.querySelectorAll(".aqi_location_outer").forEach(function(el) {
+                    el.innerHTML = "";
+                });
+            }
             try {
-                jQuery(".station-observations .aqi").text(forecast_label_text("$obs.label.no_data") + " (" + aqiNoDataCategory + ")");
+                document.querySelectorAll(".station-observations .aqi").forEach(function(el) {
+                    el.textContent = forecast_label_text("$obs.label.no_data") + " (" + aqiNoDataCategory + ")";
+                });
             } catch (err) {
                 // AQI not in the station observation table, so silently exit
             }
@@ -1086,9 +1150,18 @@ function forecast_render_common(data) {
 
     forecast_render_source(data);
     forecast_register_external_observations("forecast", data, {epoch: lastUpdated});
-    jQuery(".onehr_forecasts").html(forecast_render_hourly_tiles(hourly, 16, "forecast-1hour"));
-    jQuery(".threehr_forecasts").html(forecast_render_hourly_tiles(threeHourly, 8, "forecast-3hour"));
-    jQuery(".day_forecasts").html(forecast_render_daily_tiles(daily, 7));
+    const onehrHtml = forecast_render_hourly_tiles(hourly, 16, "forecast-1hour");
+    const threehrHtml = forecast_render_hourly_tiles(threeHourly, 8, "forecast-3hour");
+    const dailyHtml = forecast_render_daily_tiles(daily, 7);
+    document.querySelectorAll(".onehr_forecasts").forEach(function(el) {
+        el.innerHTML = onehrHtml;
+    });
+    document.querySelectorAll(".threehr_forecasts").forEach(function(el) {
+        el.innerHTML = threehrHtml;
+    });
+    document.querySelectorAll(".day_forecasts").forEach(function(el) {
+        el.innerHTML = dailyHtml;
+    });
     forecast_render_relative_timestamps();
     forecast_start_relative_timer();
     if (typeof forecast_sync_row_height === "function") {
@@ -1104,7 +1177,9 @@ function update_forecast_data(data) {
     belchertown_debug(data);
 
     if (forecast_provider == "N/A") {
-        jQuery(".forecastrow").hide();
+        document.querySelectorAll(".forecastrow").forEach(function(el) {
+            el.style.display = "none";
+        });
         belchertown_debug("Forecast: No provider, hiding forecastrow");
         return;
     } else if (forecast_has_common_schema(data)) {

--- a/skins/new-belchertown/js/new-belchertown-mqtt.js.tmpl
+++ b/skins/new-belchertown/js/new-belchertown-mqtt.js.tmpl
@@ -15,25 +15,23 @@ function ajaximages(section = false, reload_timer_interval_seconds = false) {
             var radar_img = document.querySelectorAll(".radar-map img")[0].src;
             var new_radar_img = radar_img + "&t=" + Math.floor(Math.random() * 999999999);
             document.querySelectorAll(".radar-map img")[0].src = new_radar_img;
-            //var radar_html = jQuery('.radar-map').children('img').attr('src').split('?')[0] // Get the img src and remove everything after "?" so we don't stack ?'s onto the image during updates
-            //jQuery('.radar-map').children('img').attr('src', radar_html + "?" + Math.floor(Math.random() * 999999999));
         }
         // Reload iframe - https://stackoverflow.com/a/4249946/1177153
         if (document.querySelectorAll(".radar-map iframe").length > 0) {
-            jQuery(".radar-map iframe").each(function() {
-                jQuery(this).attr('src', function(i, val) {return val;});
+            document.querySelectorAll(".radar-map iframe").forEach(function(frame) {
+                frame.src = frame.src;
             });
         }
     } else if (!section || section != "radar") {
         belchertown_debug("Updating " + section + " images");
         // Reload images
-        jQuery('.' + section + ' img').each(function() {
-            new_image_url = jQuery(this).attr('src').split('?')[0] + "?" + Math.floor(Math.random() * 999999999);
-            jQuery(this).attr('src', new_image_url);
+        document.querySelectorAll('.' + section + ' img').forEach(function(img) {
+            new_image_url = img.getAttribute('src').split('?')[0] + "?" + Math.floor(Math.random() * 999999999);
+            img.src = new_image_url;
         });
         // Reload iframes
-        jQuery('.' + section + ' iframe').each(function() {
-            jQuery(this).attr('src', function(i, val) {return val;});
+        document.querySelectorAll('.' + section + ' iframe').forEach(function(frame) {
+            frame.src = frame.src;
         });
     }
     // Set the new timer
@@ -91,12 +89,12 @@ function mqtt_ensure_status_info_button() {
         return;
     }
 
-    var updated = jQuery(".updated").first();
-    if (!updated.length || jQuery(".mqtt-status-info").length) {
+    var updated = document.querySelector(".updated");
+    if (!updated || document.querySelector(".mqtt-status-info")) {
         return;
     }
 
-    updated.after(
+    updated.insertAdjacentHTML("afterend",
         " <button type='button' class='mqtt-status-info' aria-label='" + belchertown_label_html("$obs.label.mqtt_live_update_details") + "'>" +
         "<i class='fa fa-info' aria-hidden='true'></i>" +
         "</button>"
@@ -108,7 +106,7 @@ function mqtt_ensure_status_modal() {
         return;
     }
 
-    if (jQuery("#mqtt-status-modal").length) {
+    if (document.getElementById("mqtt-status-modal")) {
         return;
     }
 
@@ -137,7 +135,7 @@ function mqtt_ensure_status_modal() {
     modal += "</div>";
     modal += "</div>";
     modal += "</div>";
-    jQuery("body").append(modal);
+    document.body.insertAdjacentHTML("beforeend", modal);
 }
 
 function mqtt_modal_normalized_text(value) {
@@ -188,16 +186,16 @@ function mqtt_set_latest_packet_data(payload) {
 }
 
 function mqtt_render_live_data_modal(modal) {
-    var container = modal.find(".mqtt-status-live-data");
+    var container = modal.querySelector(".mqtt-status-live-data");
     var rows = mqtt_latest_packet_rows;
     var html = "";
 
-    if (!container.length) {
+    if (!container) {
         return;
     }
 
     if (!rows.length) {
-        container.hide();
+        container.style.display = "none";
         return;
     }
 
@@ -210,19 +208,28 @@ function mqtt_render_live_data_modal(modal) {
     });
     html += "</tbody></table>";
 
-    container.find(".mqtt-status-live-data-rows").html(html);
-    container.show();
+    var rowsContainer = container.querySelector(".mqtt-status-live-data-rows");
+    if (rowsContainer) {
+        rowsContainer.innerHTML = html;
+    }
+    container.style.display = "";
 }
 
 function mqtt_render_status_modal() {
-    var modal = jQuery("#mqtt-status-modal");
-    if (!modal.length) {
+    var modal = document.getElementById("mqtt-status-modal");
+    if (!modal) {
         return;
     }
 
-    modal.find(".mqtt-status-detail-message").text(mqtt_status_detail.message || "");
-    modal.find(".mqtt-status-detail-relative").text(mqtt_status_detail.relative_time || "");
-    modal.find(".mqtt-status-detail-absolute").text(mqtt_status_detail.absolute_time || "");
+    var setText = function(selector, value) {
+        var el = modal.querySelector(selector);
+        if (el) {
+            el.textContent = value;
+        }
+    };
+    setText(".mqtt-status-detail-message", mqtt_status_detail.message || "");
+    setText(".mqtt-status-detail-relative", mqtt_status_detail.relative_time || "");
+    setText(".mqtt-status-detail-absolute", mqtt_status_detail.absolute_time || "");
     mqtt_render_live_data_modal(modal);
 }
 
@@ -237,23 +244,21 @@ function mqtt_set_status_detail(message, epoch) {
 }
 
 function mqtt_show_status_modal() {
-    var modal = jQuery("#mqtt-status-modal");
-    if (!modal.length) {
+    var modal = document.getElementById("mqtt-status-modal");
+    if (!modal || typeof bootstrap === "undefined" || !bootstrap.Modal) {
         return;
     }
 
-    if (jQuery.fn.modal) {
-        modal.modal("show");
-    }
+    bootstrap.Modal.getOrCreateInstance(modal).show();
 }
 
 function mqtt_hide_status_modal() {
-    var modal = jQuery("#mqtt-status-modal");
-    if (!modal.length || !jQuery.fn.modal) {
+    var modal = document.getElementById("mqtt-status-modal");
+    if (!modal || typeof bootstrap === "undefined" || !bootstrap.Modal) {
         return;
     }
 
-    modal.modal("hide");
+    bootstrap.Modal.getOrCreateInstance(modal).hide();
 }
 
 function mqtt_bind_status_info_button() {
@@ -262,14 +267,17 @@ function mqtt_bind_status_info_button() {
     }
 
     mqtt_status_info_handler_bound = true;
-    jQuery(document).on("click.belchertownMqttStatus", ".mqtt-status-info", function(event) {
-        event.preventDefault();
-        mqtt_ensure_status_modal();
-        mqtt_render_status_modal();
-        mqtt_show_status_modal();
-    });
-    jQuery(document).on("click.belchertownMqttStatus", ".mqtt-status-modal-dismiss", function() {
-        mqtt_hide_status_modal();
+    document.addEventListener("click", function(event) {
+        if (event.target.closest(".mqtt-status-info")) {
+            event.preventDefault();
+            mqtt_ensure_status_modal();
+            mqtt_render_status_modal();
+            mqtt_show_status_modal();
+            return;
+        }
+        if (event.target.closest(".mqtt-status-modal-dismiss")) {
+            mqtt_hide_status_modal();
+        }
     });
 }
 
@@ -313,12 +321,14 @@ function mqtt_render_relative_updated_status() {
         mqtt_relative_updated_detail_message || mqtt_relative_updated_message,
         mqtt_relative_updated_epoch
     );
-    var updated = jQuery(".updated")
-        .text(mqtt_sentence_text([mqtt_relative_updated_message, relative_time]))
-        .removeAttr("title");
-    if (mqtt_relative_updated_suffix_html) {
-        updated.append(mqtt_relative_updated_suffix_html);
-    }
+    var updatedText = mqtt_sentence_text([mqtt_relative_updated_message, relative_time]);
+    document.querySelectorAll(".updated").forEach(function(el) {
+        el.textContent = updatedText;
+        el.removeAttribute("title");
+        if (mqtt_relative_updated_suffix_html) {
+            el.insertAdjacentHTML("beforeend", mqtt_relative_updated_suffix_html);
+        }
+    });
 }
 
 function mqtt_start_relative_updated_timer() {
@@ -344,19 +354,25 @@ function mqtt_clear_receiving_indicator() {
         clearTimeout(mqtt_receiving_indicator_timeout);
         mqtt_receiving_indicator_timeout = null;
     }
-    jQuery(".onlineMarker").removeClass("mqtt-receiving");
+    document.querySelectorAll(".onlineMarker").forEach(function(el) {
+        el.classList.remove("mqtt-receiving");
+    });
 }
 
 function mqtt_mark_receiving_data() {
-    var marker = jQuery(".onlineMarker");
+    var markers = document.querySelectorAll(".onlineMarker");
     if (mqtt_receiving_indicator_timeout !== null) {
         clearTimeout(mqtt_receiving_indicator_timeout);
     }
-    marker.removeClass("mqtt-receiving");
-    if (marker.length) {
-        marker[0].offsetWidth;
+    markers.forEach(function(el) {
+        el.classList.remove("mqtt-receiving");
+    });
+    if (markers.length) {
+        markers[0].offsetWidth;
     }
-    marker.addClass("mqtt-receiving");
+    markers.forEach(function(el) {
+        el.classList.add("mqtt-receiving");
+    });
     mqtt_receiving_indicator_timeout = setTimeout(function() {
         mqtt_receiving_indicator_timeout = null;
         mqtt_clear_receiving_indicator();
@@ -366,13 +382,20 @@ function mqtt_mark_receiving_data() {
 function mqtt_set_updated_html(html) {
     mqtt_clear_relative_updated_status();
     mqtt_clear_receiving_indicator();
-    jQuery(".updated").removeAttr("title").html(html);
+    document.querySelectorAll(".updated").forEach(function(el) {
+        el.removeAttribute("title");
+        el.innerHTML = html;
+    });
 }
 
 function mqtt_set_updated_text(text) {
     mqtt_clear_relative_updated_status();
     mqtt_clear_receiving_indicator();
-    jQuery(".updated").removeAttr("title").text(belchertown_label_text(text));
+    var updatedText = belchertown_label_text(text);
+    document.querySelectorAll(".updated").forEach(function(el) {
+        el.removeAttribute("title");
+        el.textContent = updatedText;
+    });
 }
 
 function mqtt_set_relative_updated_status(message, epoch, suffix_html, detail_message) {
@@ -395,7 +418,9 @@ function mqtt_restart_live_updates(event) {
         event.preventDefault();
     }
 
-    jQuery(".restart-interval").prop("disabled", true);
+    document.querySelectorAll(".restart-interval").forEach(function(el) {
+        el.disabled = true;
+    });
     mqtt_clear_reconnect_timeout();
     mqtt_reset_reconnect_backoff();
     mqtt_set_updated_text("$obs.label.mqtt_websockets_connecting");
@@ -404,7 +429,7 @@ function mqtt_restart_live_updates(event) {
     if (typeof ajaxweewx === "function") {
         reloadPromise = ajaxweewx();
     } else {
-        reloadPromise = jQuery.Deferred().resolve(null).promise();
+        reloadPromise = Promise.resolve(null);
     }
 
     reloadPromise.then(function(weewx_data) {
@@ -438,7 +463,11 @@ function mqtt_bind_restart_button() {
     }
 
     mqtt_restart_handler_bound = true;
-    jQuery(document).on("click.belchertownMqttRestart", ".restart-interval", mqtt_restart_live_updates);
+    document.addEventListener("click", function(event) {
+        if (event.target.closest(".restart-interval")) {
+            mqtt_restart_live_updates(event);
+        }
+    });
 }
 
 mqtt_bind_restart_button();
@@ -506,13 +535,37 @@ function mqtt_schedule_reconnect(reason, reset_backoff) {
     }, delay_ms);
 }
 
+function mqtt_set_display(selector, value) {
+    document.querySelectorAll(selector).forEach(function(el) {
+        el.style.display = value;
+    });
+}
+
+function mqtt_set_html(selector, html) {
+    if (typeof html === "undefined") {
+        return; // match jQuery .html(undefined), which left content unchanged
+    }
+    document.querySelectorAll(selector).forEach(function(el) {
+        el.innerHTML = html;
+    });
+}
+
+function mqtt_set_text(selector, text) {
+    if (typeof text === "undefined") {
+        return; // match jQuery .text(undefined), which left content unchanged
+    }
+    document.querySelectorAll(selector).forEach(function(el) {
+        el.textContent = text;
+    });
+}
+
 function mqtt_set_disconnected_status(message, epoch, show_restart) {
     mqttConnected = false;
     mqtt_clear_activity_timeout();
     mqtt_clear_stale_timeout();
-    jQuery(".onlineMarker").hide();
-    jQuery(".offlineMarker").show();
-    jQuery(".loadingMarker").hide();
+    mqtt_set_display(".onlineMarker", "none");
+    mqtt_set_display(".offlineMarker", "");
+    mqtt_set_display(".loadingMarker", "none");
 
     var updated_epoch = epoch || mqtt_last_data_epoch || "$current.dateTime.raw";
     var restart_button = show_restart ? mqtt_restart_button_html() : "";
@@ -624,9 +677,9 @@ function connect() {
     }
     reported = belchertown_label_text("$obs.label.mqtt_websockets_connecting") + " " + belchertown_label_text("$obs.label.header_last_updated") + " " + updated;
     mqtt_set_updated_text(reported);
-    jQuery(".onlineMarker").hide();
-    jQuery(".offlineMarker").hide();
-    jQuery(".loadingMarker").show();
+    mqtt_set_display(".onlineMarker", "none");
+    mqtt_set_display(".offlineMarker", "none");
+    mqtt_set_display(".loadingMarker", "");
     belchertown_debug("MQTT: UI markers updated for connection state");
 
     // #if $Extras.has_key("mqtt_websockets_host_kiosk") and $Extras.mqtt_websockets_host_kiosk != ""
@@ -714,9 +767,9 @@ function onConnect() {
         reported = belchertown_label_text("$obs.label.mqtt_websockets_waiting") + " " + belchertown_label_text("$obs.label.header_last_updated") + " " + updated;
     }
     mqtt_set_updated_text(reported);
-    jQuery(".onlineMarker").hide();
-    jQuery(".offlineMarker").hide();
-    jQuery(".loadingMarker").show();
+    mqtt_set_display(".onlineMarker", "none");
+    mqtt_set_display(".offlineMarker", "none");
+    mqtt_set_display(".loadingMarker", "");
     belchertown_debug("MQTT: Subscribing to topic: $Extras.mqtt_websockets_topic");
     client.subscribe("$Extras.mqtt_websockets_topic");
     belchertown_debug("MQTT: Topic subscription request sent");
@@ -823,9 +876,9 @@ function get_mqtt_status_elements() {
     }
 
     mqttStatusElements = {
-        onlineMarkerEl: jQuery(".onlineMarker"),
-        offlineMarkerEl: jQuery(".offlineMarker"),
-        loadingMarkerEl: jQuery(".loadingMarker")
+        onlineMarkerEl: document.querySelectorAll(".onlineMarker"),
+        offlineMarkerEl: document.querySelectorAll(".offlineMarker"),
+        loadingMarkerEl: document.querySelectorAll(".loadingMarker")
     };
 
     return mqttStatusElements;
@@ -839,8 +892,8 @@ function get_station_observation_cache() {
     stationObservationElementsByKey = {};
     stationObservationUseGroupingByKey = {};
 
-    jQuery('.station-observations').find("span").each(function() {
-        var rawClass = jQuery(this).attr("class");
+    document.querySelectorAll(".station-observations span").forEach(function(span) {
+        var rawClass = span.getAttribute("class");
         if (!rawClass) {
             return;
         }
@@ -855,7 +908,7 @@ function get_station_observation_cache() {
         }
 
         if (!stationObservationElementsByKey.hasOwnProperty(elementClass)) {
-            stationObservationElementsByKey[elementClass] = jQuery("." + elementClass);
+            stationObservationElementsByKey[elementClass] = document.querySelectorAll("." + elementClass);
             stationObservationUseGroupingByKey[elementClass] = !(elementClass === "barometer" || elementClass === "pressure" || elementClass === "altimeter" || elementClass === "cloudbase");
         }
     });
@@ -912,7 +965,7 @@ function onMessageArrived(message) {
     var payload_size = message.payloadString.length;
     belchertown_debug("MQTT: [Msg #" + mqtt_message_count + "] Message received - Size: " + payload_size + " bytes, Topic: " + message.destinationName);
     try {
-        mqtt_payload = jQuery.parseJSON(message.payloadString);
+        mqtt_payload = JSON.parse(message.payloadString);
         mqtt_set_latest_packet_data(mqtt_payload);
         schedule_mqtt_ui_update(mqtt_payload);
         belchertown_debug("MQTT: [Msg #" + mqtt_message_count + "] Message processed successfully");
@@ -965,8 +1018,8 @@ function parse_mqtt_number(payload, key) {
 }
 
 function update_almanac_diagram_from_mqtt(payload) {
-    var diagram = jQuery(".almanac-diagram");
-    if (!diagram.length) {
+    var diagram = document.querySelector(".almanac-diagram");
+    if (!diagram) {
         return;
     }
 
@@ -982,12 +1035,12 @@ function update_almanac_diagram_from_mqtt(payload) {
 
     var getDiagramValue = function(dataKey) {
         var attrName = "data-" + dataKey.replace(/([A-Z])/g, "-$1").toLowerCase();
-        var attrValue = parseFloat(diagram.attr(attrName));
+        var attrValue = parseFloat(diagram.getAttribute(attrName));
         if (isFinite(attrValue)) {
             return attrValue;
         }
 
-        var dataValue = parseFloat(diagram.data(dataKey));
+        var dataValue = parseFloat(diagram.dataset[dataKey]);
         return isFinite(dataValue) ? dataValue : null;
     };
 
@@ -1007,29 +1060,25 @@ function update_almanac_diagram_from_mqtt(payload) {
             set_epoch: getDiagramValue("moonSetEpoch"),
             x_offset: getDiagramValue("moonXOffset")
         },
-        centering_mode: String(diagram.attr("data-centering-mode") || diagram.data("centeringMode") || "off").toLowerCase(),
+        centering_mode: String(diagram.getAttribute("data-centering-mode") || "off").toLowerCase(),
         current_ts: currentTs === null ? getDiagramValue("currentTs") : currentTs
     };
 
     if (solarAz !== null) {
         diagramData.sun.azimuth = solarAz;
-        diagram.data("sunAz", solarAz);
-        diagram.attr("data-sun-az", solarAz.toFixed(3));
+        diagram.setAttribute("data-sun-az", solarAz.toFixed(3));
     }
     if (solarAlt !== null) {
         diagramData.sun.altitude = solarAlt;
-        diagram.data("sunAlt", solarAlt);
-        diagram.attr("data-sun-alt", solarAlt.toFixed(3));
+        diagram.setAttribute("data-sun-alt", solarAlt.toFixed(3));
     }
     if (lunarAz !== null) {
         diagramData.moon.azimuth = lunarAz;
-        diagram.data("moonAz", lunarAz);
-        diagram.attr("data-moon-az", lunarAz.toFixed(3));
+        diagram.setAttribute("data-moon-az", lunarAz.toFixed(3));
     }
     if (lunarAlt !== null) {
         diagramData.moon.altitude = lunarAlt;
-        diagram.data("moonAlt", lunarAlt);
-        diagram.attr("data-moon-alt", lunarAlt.toFixed(3));
+        diagram.setAttribute("data-moon-alt", lunarAlt.toFixed(3));
     }
 
     belchertown_debug(
@@ -1043,7 +1092,7 @@ function update_almanac_diagram_from_mqtt(payload) {
 // Handle MQTT message
 function update_current_wx(data) {
     if (typeof data === "string") {
-        data = jQuery.parseJSON(data);
+        data = JSON.parse(data);
     }
     data = normalize_mqtt_payload(data);
     mqtt_note_message_activity(data);
@@ -1114,9 +1163,9 @@ function update_current_wx(data) {
         mqtt_set_relative_updated_status(updated_text, epoch);
     }
     // If we're in this function, show the online beacon and hide the others
-    onlineMarkerEl.show(); // Show the online beacon
-    offlineMarkerEl.hide();
-    loadingMarkerEl.hide();
+    onlineMarkerEl.forEach(function(el) { el.style.display = ""; }); // Show the online beacon
+    offlineMarkerEl.forEach(function(el) { el.style.display = "none"; });
+    loadingMarkerEl.forEach(function(el) { el.style.display = "none"; });
 
     // Update the station observation box elements
     station_mqtt_data = Object.keys(data); // Turn data (mqtt message) into an object we can forEach
@@ -1170,7 +1219,9 @@ function update_current_wx(data) {
             useGrouping: stationObservationUseGroupingByKey[observationKey]
         }) + unit_label_array[observationKey];
 
-        stationObservationElementsByKey[observationKey].html(html_output);
+        stationObservationElementsByKey[observationKey].forEach(function(el) {
+            el.innerHTML = html_output;
+        });
     });
     // End dynamic station observation box
 
@@ -1180,79 +1231,79 @@ function update_current_wx(data) {
         // Help from: https://stackoverflow.com/a/40152286/1177153 and https://stackoverflow.com/a/31581206/1177153
         outTemp = parseFloat(parseFloat(data["outTemp_F"])).toLocaleString("$system_locale_js", {minimumFractionDigits: unit_rounding_array["outTemp"], maximumFractionDigits: unit_rounding_array["outTemp"]});
         get_outTemp_color("degree_F", outTemp);
-        jQuery(".outtemp").html(outTemp);
+        mqtt_set_html(".outtemp", outTemp);
     }
 
     // Temperature C
     if (data.hasOwnProperty("outTemp_C")) {
         outTemp = parseFloat(parseFloat(data["outTemp_C"])).toLocaleString("$system_locale_js", {minimumFractionDigits: unit_rounding_array["outTemp"], maximumFractionDigits: unit_rounding_array["outTemp"]});
         get_outTemp_color("degree_C", outTemp);
-        jQuery(".outtemp").html(outTemp);
+        mqtt_set_html(".outtemp", outTemp);
     }
 
     // Apparent Temperature US
     if (data.hasOwnProperty("appTemp_F")) {
-        jQuery(".feelslike").text(belchertown_label_text("$obs.label.feels_like") + " " + parseFloat(parseFloat(data["appTemp_F"])).toLocaleString("$system_locale_js", {minimumFractionDigits: unit_rounding_array["outTemp"], maximumFractionDigits: unit_rounding_array["outTemp"]}) + " " + belchertown_label_text("$unit.label.outTemp"));
+        mqtt_set_text(".feelslike", belchertown_label_text("$obs.label.feels_like") + " " + parseFloat(parseFloat(data["appTemp_F"])).toLocaleString("$system_locale_js", {minimumFractionDigits: unit_rounding_array["outTemp"], maximumFractionDigits: unit_rounding_array["outTemp"]}) + " " + belchertown_label_text("$unit.label.outTemp"));
     }
 
     // Apparent Temperature Metric
     if (data.hasOwnProperty("appTemp_C")) {
-        jQuery(".feelslike").text(belchertown_label_text("$obs.label.feels_like") + " " + parseFloat(parseFloat(data["appTemp_C"])).toLocaleString("$system_locale_js", {minimumFractionDigits: unit_rounding_array["outTemp"], maximumFractionDigits: unit_rounding_array["outTemp"]}) + " " + belchertown_label_text("$unit.label.outTemp"));
+        mqtt_set_text(".feelslike", belchertown_label_text("$obs.label.feels_like") + " " + parseFloat(parseFloat(data["appTemp_C"])).toLocaleString("$system_locale_js", {minimumFractionDigits: unit_rounding_array["outTemp"], maximumFractionDigits: unit_rounding_array["outTemp"]}) + " " + belchertown_label_text("$unit.label.outTemp"));
     }
 
     // Wind
     if (data.hasOwnProperty("windDir")) {
         rotateThis(data["windDir"]);
-        jQuery(".curwinddeg").html(parseFloat(data["windDir"]).toFixed(0) + "&deg;");
-        jQuery(".curwinddir").html(highcharts_tooltip_factory(parseFloat(data["windDir"]).toFixed(0), "windDir"));
+        mqtt_set_html(".curwinddeg", parseFloat(data["windDir"]).toFixed(0) + "&deg;");
+        mqtt_set_html(".curwinddir", highcharts_tooltip_factory(parseFloat(data["windDir"]).toFixed(0), "windDir"));
     }
 
     if (data.hasOwnProperty("windSpeed_mph")) {
-        jQuery(".curwindspeed").html(parseFloat(parseFloat(data["windSpeed_mph"])).toLocaleString("$system_locale_js", {minimumFractionDigits: unit_rounding_array["windSpeed"], maximumFractionDigits: unit_rounding_array["windSpeed"]}));
-        jQuery(".beaufort").html(beaufort_cat(kts_to_beaufort(parseFloat(data["windGust_mph"]) * 0.8689758)));
+        mqtt_set_html(".curwindspeed", parseFloat(parseFloat(data["windSpeed_mph"])).toLocaleString("$system_locale_js", {minimumFractionDigits: unit_rounding_array["windSpeed"], maximumFractionDigits: unit_rounding_array["windSpeed"]}));
+        mqtt_set_html(".beaufort", beaufort_cat(kts_to_beaufort(parseFloat(data["windGust_mph"]) * 0.8689758)));
     }
     if (data.hasOwnProperty("windSpeed_kph")) {
-        jQuery(".curwindspeed").html(parseFloat(parseFloat(data["windSpeed_kph"])).toLocaleString("$system_locale_js", {minimumFractionDigits: unit_rounding_array["windSpeed"], maximumFractionDigits: unit_rounding_array["windSpeed"]}));
-        jQuery(".beaufort").html(beaufort_cat(kts_to_beaufort(parseFloat(data["windGust_kph"]) * 0.5399565)));
+        mqtt_set_html(".curwindspeed", parseFloat(parseFloat(data["windSpeed_kph"])).toLocaleString("$system_locale_js", {minimumFractionDigits: unit_rounding_array["windSpeed"], maximumFractionDigits: unit_rounding_array["windSpeed"]}));
+        mqtt_set_html(".beaufort", beaufort_cat(kts_to_beaufort(parseFloat(data["windGust_kph"]) * 0.5399565)));
     }
     if (data.hasOwnProperty("windSpeed_mps")) {
-        jQuery(".curwindspeed").html(parseFloat(parseFloat(data["windSpeed_mps"])).toLocaleString("$system_locale_js", {minimumFractionDigits: unit_rounding_array["windSpeed"], maximumFractionDigits: unit_rounding_array["windSpeed"]}));
-        jQuery(".beaufort").html(beaufort_cat(kts_to_beaufort(parseFloat(data["windGust_mps"]) * 1.943844)));
+        mqtt_set_html(".curwindspeed", parseFloat(parseFloat(data["windSpeed_mps"])).toLocaleString("$system_locale_js", {minimumFractionDigits: unit_rounding_array["windSpeed"], maximumFractionDigits: unit_rounding_array["windSpeed"]}));
+        mqtt_set_html(".beaufort", beaufort_cat(kts_to_beaufort(parseFloat(data["windGust_mps"]) * 1.943844)));
     }
     if (data.hasOwnProperty("windSpeed_beaufort")) {
-        jQuery(".curwindspeed").html(parseFloat(parseFloat(data["windSpeed_beaufort"])).toLocaleString("$system_locale_js", {minimumFractionDigits: unit_rounding_array["windSpeed"], maximumFractionDigits: unit_rounding_array["windSpeed"]}));
-        jQuery(".beaufort").html(beaufort_cat(parseFloat(data["windGust_beaufort"])));
+        mqtt_set_html(".curwindspeed", parseFloat(parseFloat(data["windSpeed_beaufort"])).toLocaleString("$system_locale_js", {minimumFractionDigits: unit_rounding_array["windSpeed"], maximumFractionDigits: unit_rounding_array["windSpeed"]}));
+        mqtt_set_html(".beaufort", beaufort_cat(parseFloat(data["windGust_beaufort"])));
     }
     if (data.hasOwnProperty("windSpeed_knot")) {
-        jQuery(".curwindspeed").html(parseFloat(parseFloat(data["windSpeed_knot"])).toLocaleString("$system_locale_js", {minimumFractionDigits: unit_rounding_array["windSpeed"], maximumFractionDigits: unit_rounding_array["windSpeed"]}));
-        jQuery(".beaufort").html(beaufort_cat(kts_to_beaufort(parseFloat(data["windGust_knot"]))));
+        mqtt_set_html(".curwindspeed", parseFloat(parseFloat(data["windSpeed_knot"])).toLocaleString("$system_locale_js", {minimumFractionDigits: unit_rounding_array["windSpeed"], maximumFractionDigits: unit_rounding_array["windSpeed"]}));
+        mqtt_set_html(".beaufort", beaufort_cat(kts_to_beaufort(parseFloat(data["windGust_knot"]))));
     }
 
     if (data.hasOwnProperty("beaufort")) {
-        jQuery(".beaufort").html(beaufort_cat(parseFloat(data["beaufort"])));
+        mqtt_set_html(".beaufort", beaufort_cat(parseFloat(data["beaufort"])));
     }
 
     if (data.hasOwnProperty("windGust_mph")) {
-        jQuery(".curwindgust").html(parseFloat(parseFloat(data["windGust_mph"])).toLocaleString("$system_locale_js", {minimumFractionDigits: unit_rounding_array["windGust"], maximumFractionDigits: unit_rounding_array["windGust"]}));
+        mqtt_set_html(".curwindgust", parseFloat(parseFloat(data["windGust_mph"])).toLocaleString("$system_locale_js", {minimumFractionDigits: unit_rounding_array["windGust"], maximumFractionDigits: unit_rounding_array["windGust"]}));
     }
     if (data.hasOwnProperty("windGust_kph")) {
-        jQuery(".curwindgust").html(parseFloat(parseFloat(data["windGust_kph"])).toLocaleString("$system_locale_js", {minimumFractionDigits: unit_rounding_array["windGust"], maximumFractionDigits: unit_rounding_array["windGust"]}));
+        mqtt_set_html(".curwindgust", parseFloat(parseFloat(data["windGust_kph"])).toLocaleString("$system_locale_js", {minimumFractionDigits: unit_rounding_array["windGust"], maximumFractionDigits: unit_rounding_array["windGust"]}));
     }
     if (data.hasOwnProperty("windGust_mps")) {
-        jQuery(".curwindgust").html(parseFloat(parseFloat(data["windGust_mps"])).toLocaleString("$system_locale_js", {minimumFractionDigits: unit_rounding_array["windGust"], maximumFractionDigits: unit_rounding_array["windGust"]}));
+        mqtt_set_html(".curwindgust", parseFloat(parseFloat(data["windGust_mps"])).toLocaleString("$system_locale_js", {minimumFractionDigits: unit_rounding_array["windGust"], maximumFractionDigits: unit_rounding_array["windGust"]}));
     }
     if (data.hasOwnProperty("windGust_beaufort")) {
-        jQuery(".curwindgust").html(parseFloat(parseFloat(data["windGust_beaufort"])).toLocaleString("$system_locale_js", {minimumFractionDigits: unit_rounding_array["windSpeed"], maximumFractionDigits: unit_rounding_array["windSpeed"]}));
+        mqtt_set_html(".curwindgust", parseFloat(parseFloat(data["windGust_beaufort"])).toLocaleString("$system_locale_js", {minimumFractionDigits: unit_rounding_array["windSpeed"], maximumFractionDigits: unit_rounding_array["windSpeed"]}));
     }
     if (data.hasOwnProperty("windGust_knot")) {
-        jQuery(".curwindgust").html(parseFloat(parseFloat(data["windGust_knot"])).toLocaleString("$system_locale_js", {minimumFractionDigits: unit_rounding_array["windSpeed"], maximumFractionDigits: unit_rounding_array["windSpeed"]}));
+        mqtt_set_html(".curwindgust", parseFloat(parseFloat(data["windGust_knot"])).toLocaleString("$system_locale_js", {minimumFractionDigits: unit_rounding_array["windSpeed"], maximumFractionDigits: unit_rounding_array["windSpeed"]}));
     }
 
     if (data.hasOwnProperty("windchill")) {
-        jQuery(".curwindchill").text(parseFloat(parseFloat(data["windchill"])).toLocaleString("$system_locale_js", {minimumFractionDigits: unit_rounding_array["windchill"], maximumFractionDigits: unit_rounding_array["windchill"]}) + belchertown_label_text("$unit.label.outTemp"));
+        mqtt_set_text(".curwindchill", parseFloat(parseFloat(data["windchill"])).toLocaleString("$system_locale_js", {minimumFractionDigits: unit_rounding_array["windchill"], maximumFractionDigits: unit_rounding_array["windchill"]}) + belchertown_label_text("$unit.label.outTemp"));
     }
     if (data.hasOwnProperty("windchill_C")) {
-        jQuery(".curwindchill").text(parseFloat(parseFloat(data["windchill_C"])).toLocaleString("$system_locale_js", {minimumFractionDigits: unit_rounding_array["windchill"], maximumFractionDigits: unit_rounding_array["windchill"]}) + belchertown_label_text("$unit.label.outTemp"));
+        mqtt_set_text(".curwindchill", parseFloat(parseFloat(data["windchill_C"])).toLocaleString("$system_locale_js", {minimumFractionDigits: unit_rounding_array["windchill"], maximumFractionDigits: unit_rounding_array["windchill"]}) + belchertown_label_text("$unit.label.outTemp"));
     }
     mqtt_render_status_modal();
 };

--- a/skins/new-belchertown/js/new-belchertown.js.tmpl
+++ b/skins/new-belchertown/js/new-belchertown.js.tmpl
@@ -56,64 +56,88 @@ var belchertownWindyRadarViewportWidth = null;
 var belchertownWebcamReloadTimers = [];
 
 function belchertown_radar_tab_containers() {
-    return jQuery(".belchertown-radar-tabs").add("#tabs-container").filter(function() {
-        return jQuery(this).find(".tabs-menu a").length && jQuery(this).find(".belchertown-radar-tab-panel").length;
+    var candidates = Array.prototype.slice.call(document.querySelectorAll(".belchertown-radar-tabs"));
+    var tabsContainer = document.getElementById("tabs-container");
+    if (tabsContainer && candidates.indexOf(tabsContainer) === -1) {
+        candidates.push(tabsContainer);
+    }
+    return candidates.filter(function(el) {
+        return el.querySelector(".tabs-menu a") && el.querySelector(".belchertown-radar-tab-panel");
+    });
+}
+
+function belchertown_fade_in(element) {
+    element.style.opacity = "0";
+    element.style.display = "";
+    requestAnimationFrame(function() {
+        element.style.transition = "opacity 200ms";
+        element.style.opacity = "1";
+        setTimeout(function() {
+            element.style.transition = "";
+            element.style.opacity = "";
+        }, 250);
     });
 }
 
 function belchertown_activate_radar_tab(tabLink, animate) {
-    var link = jQuery(tabLink);
-    var container = link.closest(".belchertown-radar-tabs");
-    var activeTab = link.attr("href");
-
-    if (!container.length) {
-        container = link.closest("#tabs-container");
+    var link = tabLink && tabLink.jquery ? tabLink[0] : tabLink;
+    if (!link) {
+        return;
     }
-    if (!container.length || !activeTab || activeTab.charAt(0) !== "#") {
+    var container = link.closest(".belchertown-radar-tabs") || link.closest("#tabs-container");
+    var activeTab = link.getAttribute("href");
+
+    if (!container || !activeTab || activeTab.charAt(0) !== "#") {
         return;
     }
 
-    var activePanel = container.find(activeTab);
-    if (!activePanel.length) {
-        activePanel = jQuery(activeTab);
-    }
-    if (!activePanel.length) {
+    var activePanel = container.querySelector(activeTab) || document.querySelector(activeTab);
+    if (!activePanel) {
         return;
     }
 
-    link.parent().addClass("active");
-    link.parent().siblings().removeClass("active");
-    container.find(".belchertown-radar-tab-panel").not(activePanel).removeClass("is-active").hide();
-    activePanel.addClass("is-active");
+    var linkItem = link.parentElement;
+    linkItem.classList.add("active");
+    Array.prototype.forEach.call(linkItem.parentElement.children, function(sibling) {
+        if (sibling !== linkItem) {
+            sibling.classList.remove("active");
+        }
+    });
+    container.querySelectorAll(".belchertown-radar-tab-panel").forEach(function(panel) {
+        if (panel !== activePanel) {
+            panel.classList.remove("is-active");
+            panel.style.display = "none";
+        }
+    });
+    activePanel.classList.add("is-active");
     if (animate === false) {
-        activePanel.show();
+        activePanel.style.display = "";
     } else {
-        activePanel.fadeIn();
+        belchertown_fade_in(activePanel);
     }
 
     belchertown_schedule_windy_radar_scale(document, true);
 }
 
 function belchertown_initialize_radar_tabs() {
-    belchertown_radar_tab_containers().each(function() {
-        var container = jQuery(this);
-        var activeLink = container.find(".tabs-menu li.active a").first();
-        var activePanel = container.find(".belchertown-radar-tab-panel.is-active").first();
+    belchertown_radar_tab_containers().forEach(function(container) {
+        var activeLink = container.querySelector(".tabs-menu li.active a");
+        var activePanel = container.querySelector(".belchertown-radar-tab-panel.is-active");
 
-        if (!activeLink.length && activePanel.length && activePanel.attr("id")) {
-            activeLink = container.find('.tabs-menu a[href="#' + activePanel.attr("id") + '"]').first();
+        if (!activeLink && activePanel && activePanel.id) {
+            activeLink = container.querySelector('.tabs-menu a[href="#' + activePanel.id + '"]');
         }
-        if (!activeLink.length) {
-            activeLink = container.find(".tabs-menu a").first();
+        if (!activeLink) {
+            activeLink = container.querySelector(".tabs-menu a");
         }
-        if (activeLink.length) {
+        if (activeLink) {
             belchertown_activate_radar_tab(activeLink, false);
         }
     });
 }
 
 function belchertown_webcam_reload_interval(container) {
-    var interval = parseInt(jQuery(container).attr("data-webcam-reload-interval-ms"), 10);
+    var interval = parseInt(container.getAttribute("data-webcam-reload-interval-ms"), 10);
 
     if (isNaN(interval)) {
         return 300000;
@@ -123,17 +147,18 @@ function belchertown_webcam_reload_interval(container) {
 }
 
 function belchertown_reload_webcam_images(container) {
-    var containers = container ? jQuery(container) : belchertown_radar_tab_containers();
+    var containers = container ? [container] : belchertown_radar_tab_containers();
 
-    containers.find("#webcam img").each(function() {
-        var image = jQuery(this);
-        var imageUrl = image.attr("src");
+    containers.forEach(function(containerEl) {
+        containerEl.querySelectorAll("#webcam img").forEach(function(image) {
+            var imageUrl = image.getAttribute("src");
 
-        if (!imageUrl) {
-            return;
-        }
+            if (!imageUrl) {
+                return;
+            }
 
-        image.attr("src", imageUrl.split("?")[0] + "?" + Math.floor(Math.random() * 999999999));
+            image.setAttribute("src", imageUrl.split("?")[0] + "?" + Math.floor(Math.random() * 999999999));
+        });
     });
 }
 
@@ -719,10 +744,28 @@ function belchertown_readable_color(color, background, minimumRatio) {
     return belchertown_rgb_to_hex(target);
 }
 
+function belchertown_set_html(selector, html) {
+    if (typeof html === "undefined") {
+        return; // match jQuery .html(undefined), which left content unchanged
+    }
+    document.querySelectorAll(selector).forEach(function(el) {
+        el.innerHTML = html;
+    });
+}
+
+function belchertown_set_text(selector, text) {
+    if (typeof text === "undefined") {
+        return; // match jQuery .text(undefined), which left content unchanged
+    }
+    document.querySelectorAll(selector).forEach(function(el) {
+        el.textContent = text;
+    });
+}
+
 function belchertown_apply_readable_color(selector, color, minimumRatio) {
-    jQuery(selector).each(function() {
-        var background = belchertown_effective_background_color(this);
-        jQuery(this).css("color", belchertown_readable_color(color, background, minimumRatio));
+    document.querySelectorAll(selector).forEach(function(el) {
+        var background = belchertown_effective_background_color(el);
+        el.style.color = belchertown_readable_color(color, background, minimumRatio);
     });
 }
 
@@ -736,12 +779,22 @@ const AQI_MIN_CONTRAST = {
 };
 const AQI_COLOR_SELECTOR = ".wx-aqi, .wx-aqi-category, .aqi_outer, .station-observations .aqi";
 
-jQuery(document).ready(function() {
+function belchertown_on_ready(fn) {
+    if (document.readyState === "loading") {
+        document.addEventListener("DOMContentLoaded", fn);
+    } else {
+        fn();
+    }
+}
+
+belchertown_on_ready(function() {
     belchertown_decode_document_labels(document.documentElement);
 
     // Bootstrap hover tooltips
-    if (jQuery.fn.tooltip) {
-        jQuery('[data-bs-toggle="tooltip"]').tooltip()
+    if (typeof bootstrap !== "undefined" && bootstrap.Tooltip) {
+        document.querySelectorAll('[data-bs-toggle="tooltip"]').forEach(function(el) {
+            bootstrap.Tooltip.getOrCreateInstance(el);
+        });
     }
 
     // Fail-open for pages generated with deferred iframe markup.
@@ -750,8 +803,7 @@ jQuery(document).ready(function() {
     var radarTabContainers = belchertown_radar_tab_containers();
     if (radarTabContainers.length) {
         belchertown_initialize_radar_tabs();
-        radarTabContainers.each(function() {
-            var container = this;
+        radarTabContainers.forEach(function(container) {
             var reloadInterval = belchertown_webcam_reload_interval(container);
 
             belchertown_reload_webcam_images(container);
@@ -760,13 +812,20 @@ jQuery(document).ready(function() {
                     belchertown_reload_webcam_images(container);
                 }, reloadInterval));
             }
-        });
-        radarTabContainers.on("click", ".tabs-menu a", function(event) {
-            event.preventDefault();
-            belchertown_activate_radar_tab(this);
+            container.addEventListener("click", function(event) {
+                var tabAnchor = event.target.closest(".tabs-menu a");
+                if (!tabAnchor || !container.contains(tabAnchor)) {
+                    return;
+                }
+                event.preventDefault();
+                belchertown_activate_radar_tab(tabAnchor);
+            });
         });
     }
-    jQuery(window).on("resize orientationchange", function() {
+    window.addEventListener("resize", function() {
+        belchertown_schedule_windy_radar_scale(document);
+    });
+    window.addEventListener("orientationchange", function() {
         belchertown_schedule_windy_radar_scale(document);
     });
 
@@ -806,41 +865,49 @@ jQuery(document).ready(function() {
     // #end if
 
     // After charts are loaded, if an anchor tag is in the URL, let's scroll to it
-    jQuery(window).on('load', function() {
+    window.addEventListener('load', function() {
         var anchor_tag = location.hash.replace('#', '');
         if (anchor_tag != '') {
-            // Scroll the webpage to the chart. The timeout is to let jQuery finish appending the outer div so the height of the page is completed.
+            // Scroll the webpage to the chart. The timeout is to let the chart code finish appending the outer div so the height of the page is completed.
             setTimeout(function() {
-                jQuery('html, body').animate({scrollTop: jQuery('#' + anchor_tag).offset().top}, 500);
+                var anchorEl = document.getElementById(anchor_tag);
+                if (anchorEl) {
+                    window.scrollTo({top: anchorEl.getBoundingClientRect().top + window.pageYOffset, behavior: "smooth"});
+                }
             }, 500);
         }
     });
 
     // #if $Extras.has_key("back_to_top_button_enabled") and $Extras.back_to_top_button_enabled == '1'
     // Back to Top Button is visible after 400px
-    jQuery(window).scroll(function() {
-        if (jQuery(this).scrollTop() > 400) {
-            jQuery('#btn-back-to-top').css('transform', 'scale(1)');
+    var backToTopButton = document.getElementById('btn-back-to-top');
+    window.addEventListener("scroll", function() {
+        if (!backToTopButton) {
+            return;
+        }
+        if (window.pageYOffset > 400) {
+            backToTopButton.style.transform = 'scale(1)';
         } else {
-            jQuery('#btn-back-to-top').css('transform', 'scale(0)');
+            backToTopButton.style.transform = 'scale(0)';
         }
     });
 
-    jQuery('#btn-back-to-top').click(function() {
-        jQuery("html, body").animate({
-            scrollTop: 0
-        }, 1000);
-        return false;
-    });
+    if (backToTopButton) {
+        backToTopButton.addEventListener("click", function(event) {
+            event.preventDefault();
+            window.scrollTo({top: 0, behavior: "smooth"});
+        });
 
-    // #if $Extras.back_to_top_button_position == '1'
-    // Button is visible on left side
-    jQuery('#btn-back-to-top').css('left', '20px').css('right', 'auto');
-    // #end if
+        // #if $Extras.back_to_top_button_position == '1'
+        // Button is visible on left side
+        backToTopButton.style.left = '20px';
+        backToTopButton.style.right = 'auto';
+        // #end if
 
-    // #if $Extras.back_to_top_button_opacity >= '0.1' and $Extras.back_to_top_button_opacity <= '0.9'
-    jQuery('#btn-back-to-top').css('opacity', '$Extras.back_to_top_button_opacity');
-    // #end if
+        // #if $Extras.back_to_top_button_opacity >= '0.1' and $Extras.back_to_top_button_opacity <= '0.9'
+        backToTopButton.style.opacity = '$Extras.back_to_top_button_opacity';
+        // #end if
+    }
     // #end if
 
     initializeAlmanacDiagramFromDOM();
@@ -854,9 +921,12 @@ jQuery(document).ready(function() {
 
     // Style legacy celestial table markup as modern sub-cards in the extras modal.
     enhanceAlmanacExtrasModal();
-    jQuery('#almanac-modal').on('shown.bs.modal', function() {
-        enhanceAlmanacExtrasModal();
-    });
+    var almanacModalEl = document.getElementById('almanac-modal');
+    if (almanacModalEl) {
+        almanacModalEl.addEventListener('shown.bs.modal', function() {
+            enhanceAlmanacExtrasModal();
+        });
+    }
 
 });
 
@@ -923,7 +993,7 @@ function new_gradient_temp(value, min, max) {
 }
 
 function belchertown_current_theme() {
-    if (jQuery("body").hasClass("dark") || sessionStorage.getItem("currentTheme") === "dark") {
+    if (document.body.classList.contains("dark") || sessionStorage.getItem("currentTheme") === "dark") {
         return "dark";
     }
     return "light";
@@ -957,11 +1027,14 @@ function get_aqi_color(aqi) {
 }
 
 function clear_aqi_color() {
-    jQuery(AQI_COLOR_SELECTOR).css("color", "");
+    document.querySelectorAll(AQI_COLOR_SELECTOR).forEach(function(el) {
+        el.style.color = "";
+    });
 }
 
 function refresh_aqi_color() {
-    var aqiValue = jQuery(".wx-aqi").first().text();
+    var aqiEl = document.querySelector(".wx-aqi");
+    var aqiValue = aqiEl ? aqiEl.textContent : "";
     if (aqiValue) {
         get_aqi_color(aqiValue);
     }
@@ -1108,11 +1181,9 @@ function wind_compass_unit_label(obsName) {
     ) {
         return unit_label_array["windSpeed"];
     }
-    if (typeof jQuery === "function") {
-        var label = jQuery(".wind-table td.mph").first().text();
-        if (label) {
-            return label;
-        }
+    var labelCell = document.querySelector(".wind-table td.mph");
+    if (labelCell && labelCell.textContent) {
+        return labelCell.textContent;
     }
     return wind_compass_default_unit_label;
 }
@@ -1144,12 +1215,9 @@ function wind_compass_value_to_knots(value, unitLabel) {
 }
 
 function displayed_wind_compass_knots(obsName) {
-    if (typeof jQuery !== "function") {
-        return null;
-    }
-
     var selector = obsName == "windGust" ? ".curwindgust" : ".curwindspeed";
-    var displayedValue = jQuery(selector).first().text();
+    var displayedEl = document.querySelector(selector);
+    var displayedValue = displayedEl ? displayedEl.textContent : "";
     return wind_compass_value_to_knots(displayedValue, wind_compass_unit_label(obsName));
 }
 
@@ -1272,16 +1340,25 @@ function render_wind_compass_marker(direction, windSpeedKnots, windGustKnots) {
     var parsedWindSpeedKnots = parse_wind_compass_knots(windSpeedKnots);
     var parsedWindGustKnots = parse_wind_compass_knots(windGustKnots);
     var selectedKnots = wind_compass_source == "windGust" ? parsedWindGustKnots : parsedWindSpeedKnots;
-    var arrow = jQuery(".arrow");
+    var arrows = document.querySelectorAll(".arrow");
+    var windArrows = document.querySelectorAll(".wind-arrow");
 
-    if (arrow.length === 0) {
+    if (arrows.length === 0) {
         return;
     }
 
     // Calm wind: hide both indicator styles (triangle and windbarb).
     if (wind_compass_is_calm(windSpeedKnots, windGustKnots)) {
-        arrow.removeClass("windbarb-marker").addClass("wind-compass-marker--hidden").empty().css("visibility", "hidden");
-        jQuery(".wind-arrow").addClass("wind-compass-marker--hidden").css("visibility", "hidden");
+        arrows.forEach(function(el) {
+            el.classList.remove("windbarb-marker");
+            el.classList.add("wind-compass-marker--hidden");
+            el.innerHTML = "";
+            el.style.visibility = "hidden";
+        });
+        windArrows.forEach(function(el) {
+            el.classList.add("wind-compass-marker--hidden");
+            el.style.visibility = "hidden";
+        });
         return;
     }
 
@@ -1290,22 +1367,34 @@ function render_wind_compass_marker(direction, windSpeedKnots, windGustKnots) {
     }
 
     // Wind is not calm: ensure indicators are visible.
-    arrow.removeClass("wind-compass-marker--hidden").css("visibility", "visible");
-    jQuery(".wind-arrow").removeClass("wind-compass-marker--hidden").css("visibility", "visible");
+    arrows.forEach(function(el) {
+        el.classList.remove("wind-compass-marker--hidden");
+        el.style.visibility = "visible";
+    });
+    windArrows.forEach(function(el) {
+        el.classList.remove("wind-compass-marker--hidden");
+        el.style.visibility = "visible";
+    });
 
     if (wind_compass_marker == "windbarb") {
-        arrow.addClass("windbarb-marker");
         if (selectedKnots === null) {
             selectedKnots = parsedWindSpeedKnots !== null ? parsedWindSpeedKnots : parsedWindGustKnots;
         }
         var svg = build_windbarb_svg(selectedKnots);
-        if (svg) {
-            arrow.html(svg);
-        } else {
-            arrow.removeClass("windbarb-marker").empty();
-        }
+        arrows.forEach(function(el) {
+            if (svg) {
+                el.classList.add("windbarb-marker");
+                el.innerHTML = svg;
+            } else {
+                el.classList.remove("windbarb-marker");
+                el.innerHTML = "";
+            }
+        });
     } else {
-        arrow.removeClass("windbarb-marker").empty();
+        arrows.forEach(function(el) {
+            el.classList.remove("windbarb-marker");
+            el.innerHTML = "";
+        });
     }
 
     rotateThis(rotation);
@@ -1447,8 +1536,9 @@ function rotateThis(newRotation) {
     if (currentRotation < 180 && (newRotation > (currentRotation + 180))) {finalRotation -= 360;}
     if (currentRotation >= 180 && (newRotation <= (currentRotation - 180))) {finalRotation += 360;}
     finalRotation += (newRotation - currentRotation);
-    jQuery(".wind-arrow").css("transform", "rotate(" + finalRotation + "deg)");
-    jQuery(".arrow").css("transform", "rotate(" + finalRotation + "deg)");
+    document.querySelectorAll(".wind-arrow, .arrow").forEach(function(el) {
+        el.style.transform = "rotate(" + finalRotation + "deg)";
+    });
 }
 
 function almanacTrackXBounds() {
@@ -1478,8 +1568,8 @@ function almanacWrapDiagramX(xValue, xOffset) {
 }
 
 function almanacDiagramCenteringMode() {
-    var diagramEl = jQuery(".almanac-diagram").first();
-    var mode = String(diagramEl.attr("data-centering-mode") || diagramEl.data("centeringMode") || "off").toLowerCase();
+    var diagramEl = document.querySelector(".almanac-diagram");
+    var mode = String((diagramEl && diagramEl.getAttribute("data-centering-mode")) || "off").toLowerCase();
     if (mode === "now" || mode === "transit") {
         return mode;
     }
@@ -1487,27 +1577,19 @@ function almanacDiagramCenteringMode() {
 }
 
 function almanacBodyXOffsetInfo(bodyKey) {
-    var diagramEl = jQuery(".almanac-diagram").first();
+    var diagramEl = document.querySelector(".almanac-diagram");
     var mode = almanacDiagramCenteringMode();
     var attrName = bodyKey === "moon" ? "data-moon-x-offset" : "data-sun-x-offset";
-    var dataKey = bodyKey === "moon" ? "moonXOffset" : "sunXOffset";
     var attrRaw;
-    var dataRaw;
     var parsed;
 
-    if (mode === "off") {
+    if (mode === "off" || !diagramEl) {
         return { value: 0, hasExplicit: false };
     }
 
-    attrRaw = diagramEl.attr(attrName);
+    attrRaw = diagramEl.getAttribute(attrName);
     parsed = parseFloat(attrRaw);
     if (attrRaw !== undefined && attrRaw !== null && String(attrRaw).trim() !== "" && isFinite(parsed)) {
-        return { value: parsed, hasExplicit: true };
-    }
-
-    dataRaw = diagramEl.data(dataKey);
-    parsed = parseFloat(dataRaw);
-    if (dataRaw !== undefined && dataRaw !== null && String(dataRaw).trim() !== "" && isFinite(parsed)) {
         return { value: parsed, hasExplicit: true };
     }
 
@@ -1547,28 +1629,20 @@ function almanacCurrentTimeToDiagramX(currentTs, currentX, fallbackCurrentX) {
 }
 
 function readAlmanacDiagramNumber(diagram, attrName, dataKey) {
-    var attrValue = parseFloat(diagram.attr(attrName));
-    var dataValue;
+    var attrValue = parseFloat(diagram.getAttribute(attrName));
 
-    if (isFinite(attrValue)) {
-        return attrValue;
-    }
-
-    dataValue = parseFloat(diagram.data(dataKey));
-    return isFinite(dataValue) ? dataValue : null;
+    return isFinite(attrValue) ? attrValue : null;
 }
 
 function writeAlmanacDiagramNumber(diagram, attrName, dataKey, value) {
     var parsed = parseFloat(value);
 
     if (!isFinite(parsed)) {
-        diagram.removeAttr(attrName);
-        diagram.removeData(dataKey);
+        diagram.removeAttribute(attrName);
         return;
     }
 
-    diagram.attr(attrName, parsed.toFixed(3));
-    diagram.data(dataKey, parsed);
+    diagram.setAttribute(attrName, parsed.toFixed(3));
 }
 
 function almanacEventBelowHorizon(riseEpoch, setEpoch, nowEpoch) {
@@ -1593,21 +1667,26 @@ function almanacEventBelowHorizon(riseEpoch, setEpoch, nowEpoch) {
 function setAlmanacDiagramBodyBelowHorizon(bodyKey, belowHorizon) {
     var key = bodyKey === "moon" ? "moon" : "sun";
 
-    jQuery(".almanac-diagram-object--" + key).toggleClass("is-below-horizon", belowHorizon);
-    jQuery(".almanac-diagram-track--" + key).toggleClass("is-below-horizon", belowHorizon);
+    var toggleAll = function(selector) {
+        document.querySelectorAll(selector).forEach(function(el) {
+            el.classList.toggle("is-below-horizon", belowHorizon);
+        });
+    };
+    toggleAll(".almanac-diagram-object--" + key);
+    toggleAll(".almanac-diagram-track--" + key);
 
-    if (key === "sun" && !jQuery(".almanac-diagram-track--sun, .almanac-diagram-track--moon").length) {
-        jQuery(".almanac-diagram-track").toggleClass("is-below-horizon", belowHorizon);
+    if (key === "sun" && !document.querySelector(".almanac-diagram-track--sun, .almanac-diagram-track--moon")) {
+        toggleAll(".almanac-diagram-track");
     }
 }
 
 function refreshAlmanacDiagramHorizonStateFromSchedule(nowEpoch) {
-    var diagram = jQuery(".almanac-diagram").first();
+    var diagram = document.querySelector(".almanac-diagram");
     var now = parseFloat(nowEpoch);
     var sunBelowHorizon;
     var moonBelowHorizon;
 
-    if (!diagram.length) {
+    if (!diagram) {
         return;
     }
 
@@ -1637,7 +1716,7 @@ function refreshAlmanacDiagramHorizonStateFromSchedule(nowEpoch) {
 var almanacDiagramHorizonTimer = null;
 
 function startAlmanacDiagramHorizonTimer() {
-    if (!jQuery(".almanac-diagram").length) {
+    if (!document.querySelector(".almanac-diagram")) {
         return;
     }
 
@@ -1653,7 +1732,7 @@ function startAlmanacDiagramHorizonTimer() {
 }
 
 function almanacExistingMarkerX(marker) {
-    var transformText = String(marker.attr("transform") || "");
+    var transformText = String(marker.getAttribute("transform") || "");
     var match = transformText.match(/translate\(\s*([-+]?\d*\.?\d+(?:e[-+]?\d+)?)/i);
     var parsed = match ? parseFloat(match[1]) : NaN;
 
@@ -1661,8 +1740,8 @@ function almanacExistingMarkerX(marker) {
 }
 
 function almanacVerticalScale() {
-    var diagramEl = jQuery(".almanac-diagram").first();
-    var scale = parseFloat(diagramEl.attr("data-vertical-scale") || diagramEl.data("verticalScale"));
+    var diagramEl = document.querySelector(".almanac-diagram");
+    var scale = parseFloat(diagramEl ? diagramEl.getAttribute("data-vertical-scale") : null);
 
     if (!isFinite(scale)) {
         return 2.5;
@@ -1694,27 +1773,20 @@ function almanacDiagramViewBox() {
 }
 
 function setAlmanacDiagramTrackBelowHorizon(selector, altitude) {
-    var track = jQuery(selector);
     var alt = parseFloat(altitude);
 
-    if (!track.length) {
-        return;
-    }
-
-    track.toggleClass("is-below-horizon", isFinite(alt) && alt < 0);
+    document.querySelectorAll(selector).forEach(function(track) {
+        track.classList.toggle("is-below-horizon", isFinite(alt) && alt < 0);
+    });
 }
 
 function setAlmanacDiagramHorizonBounds() {
-    var horizon = jQuery(".almanac-diagram-horizon");
     var xBounds = almanacTrackXBounds();
 
-    if (!horizon.length) {
-        return;
-    }
-
-    horizon
-        .attr("x1", xBounds.minX.toFixed(1))
-        .attr("x2", xBounds.maxX.toFixed(1));
+    document.querySelectorAll(".almanac-diagram-horizon").forEach(function(horizon) {
+        horizon.setAttribute("x1", xBounds.minX.toFixed(1));
+        horizon.setAttribute("x2", xBounds.maxX.toFixed(1));
+    });
 }
 
 function setAlmanacDiagramObject(selector, pathSelector, label, azimuth, altitude, currentTs, currentX) {
@@ -1722,15 +1794,22 @@ function setAlmanacDiagramObject(selector, pathSelector, label, azimuth, altitud
     var bodyKey = selector.indexOf("--moon") !== -1 ? "moon" : "sun";
     var displayLabel = belchertown_decode_html_entities(label);
     var alt = parseFloat(altitude);
-    var marker = jQuery(selector);
+    var marker = document.querySelector(selector);
     var projectedX;
     var projectedY;
     var bodyOffsetInfo = almanacBodyXOffsetInfo(bodyKey);
     var bodyOffset = bodyOffsetInfo.value;
 
-    if (!marker.length) {
+    if (!marker) {
         return;
     }
+
+    var setMarkerTitle = function() {
+        var titleEl = marker.querySelector("title");
+        if (titleEl) {
+            titleEl.textContent = displayLabel;
+        }
+    };
 
     // Python is authoritative for curve geometry. Marker position should be a
     // direct projection of live altitude at current time using the same x-offset.
@@ -1751,45 +1830,49 @@ function setAlmanacDiagramObject(selector, pathSelector, label, azimuth, altitud
 
     if (!point) {
         if (isFinite(alt)) {
-            marker.show();
-            marker.toggleClass("is-below-horizon", alt < 0);
-            marker.find("title").text(displayLabel);
+            marker.style.display = "";
+            marker.classList.toggle("is-below-horizon", alt < 0);
+            setMarkerTitle();
             return;
         }
-        marker.hide();
+        marker.style.display = "none";
         return;
     }
 
-    marker
-        .show()
-        .attr("transform", "translate(" + point.x.toFixed(1) + " " + point.y.toFixed(1) + ")")
-        .toggleClass("is-below-horizon", point.belowHorizon || (isFinite(alt) && alt < 0));
+    marker.style.display = "";
+    marker.setAttribute("transform", "translate(" + point.x.toFixed(1) + " " + point.y.toFixed(1) + ")");
+    marker.classList.toggle("is-below-horizon", point.belowHorizon || (isFinite(alt) && alt < 0));
 
-    marker.find("title").text(displayLabel);
+    setMarkerTitle();
 }
 
 function fitAlmanacDiagramViewBox(diagramData) {
-    var svg = jQuery(".almanac-diagram-svg");
+    var svgs = document.querySelectorAll(".almanac-diagram-svg");
 
-    if (!svg.length || !diagramData) {
+    if (!svgs.length || !diagramData) {
         return;
     }
 
     // Python is authoritative for content-fit SVG framing and viewport sizing.
     // Keep preserveAspectRatio aligned with server markup (no stretching).
-    svg.attr("preserveAspectRatio", "xMidYMid meet");
+    svgs.forEach(function(svg) {
+        svg.setAttribute("preserveAspectRatio", "xMidYMid meet");
+    });
 }
 
-jQuery(window).on("load orientationchange", function() {
+window.addEventListener("load", function() {
+    initializeAlmanacDiagramFromDOM();
+});
+window.addEventListener("orientationchange", function() {
     initializeAlmanacDiagramFromDOM();
 });
 
 function renderAlmanacDiagram(diagramData, preserveViewBox) {
-    var diagram = jQuery(".almanac-diagram");
+    var diagram = document.querySelector(".almanac-diagram");
 
     setAlmanacDiagramHorizonBounds();
 
-    if (!diagram.length) {
+    if (!diagram) {
         return;
     }
 
@@ -1807,7 +1890,7 @@ function renderAlmanacDiagram(diagramData, preserveViewBox) {
         diagramData["moon"] = {};
     }
 
-    // Keep DOM data-* and jQuery data cache in sync with the freshest values
+    // Keep DOM data-* attributes in sync with the freshest values
     // so MQTT incremental updates don't fall back to stale template-time values.
     var sunAz = parseFloat(diagramData["sun"]["azimuth"]);
     var sunAlt = parseFloat(diagramData["sun"]["altitude"]);
@@ -1831,57 +1914,47 @@ function renderAlmanacDiagram(diagramData, preserveViewBox) {
     resolvedCurrentX = almanacCurrentTimeToDiagramX(currentTs, currentX, fallbackCurrentX);
 
     if (isFinite(sunAz)) {
-        diagram.attr("data-sun-az", sunAz.toFixed(3));
-        diagram.data("sunAz", sunAz);
+        diagram.setAttribute("data-sun-az", sunAz.toFixed(3));
     }
     if (isFinite(sunAlt)) {
-        diagram.attr("data-sun-alt", sunAlt.toFixed(3));
-        diagram.data("sunAlt", sunAlt);
+        diagram.setAttribute("data-sun-alt", sunAlt.toFixed(3));
     }
     if (isFinite(moonAz)) {
-        diagram.attr("data-moon-az", moonAz.toFixed(3));
-        diagram.data("moonAz", moonAz);
+        diagram.setAttribute("data-moon-az", moonAz.toFixed(3));
     }
     if (isFinite(moonAlt)) {
-        diagram.attr("data-moon-alt", moonAlt.toFixed(3));
-        diagram.data("moonAlt", moonAlt);
+        diagram.setAttribute("data-moon-alt", moonAlt.toFixed(3));
     }
     writeAlmanacDiagramNumber(diagram, "data-sun-rise-epoch", "sunRiseEpoch", sunRiseEpoch);
     writeAlmanacDiagramNumber(diagram, "data-sun-set-epoch", "sunSetEpoch", sunSetEpoch);
     writeAlmanacDiagramNumber(diagram, "data-moon-rise-epoch", "moonRiseEpoch", moonRiseEpoch);
     writeAlmanacDiagramNumber(diagram, "data-moon-set-epoch", "moonSetEpoch", moonSetEpoch);
     if (isFinite(sunXOffset)) {
-        diagram.attr("data-sun-x-offset", sunXOffset.toFixed(3));
-        diagram.data("sunXOffset", sunXOffset);
+        diagram.setAttribute("data-sun-x-offset", sunXOffset.toFixed(3));
     }
     if (isFinite(moonXOffset)) {
-        diagram.attr("data-moon-x-offset", moonXOffset.toFixed(3));
-        diagram.data("moonXOffset", moonXOffset);
+        diagram.setAttribute("data-moon-x-offset", moonXOffset.toFixed(3));
     }
     if (centeringMode === "now" || centeringMode === "transit") {
-        diagram.attr("data-centering-mode", centeringMode);
-        diagram.data("centeringMode", centeringMode);
+        diagram.setAttribute("data-centering-mode", centeringMode);
     } else {
-        diagram.attr("data-centering-mode", "off");
-        diagram.data("centeringMode", "off");
+        diagram.setAttribute("data-centering-mode", "off");
     }
     if (isFinite(currentTs)) {
-        diagram.attr("data-current-ts", currentTs.toFixed(3));
-        diagram.data("currentTs", currentTs);
+        diagram.setAttribute("data-current-ts", currentTs.toFixed(3));
     }
     if (isFinite(resolvedCurrentX)) {
-        diagram.attr("data-current-x", resolvedCurrentX.toFixed(3));
-        diagram.data("currentX", resolvedCurrentX);
+        diagram.setAttribute("data-current-x", resolvedCurrentX.toFixed(3));
     }
 
-    diagram.removeClass("almanac-diagram--inactive");
+    diagram.classList.remove("almanac-diagram--inactive");
 
     // Python-authored SVG curves are authoritative. JS must never rewrite path d.
     // Keep only dynamic state classes in sync during live updates.
     setAlmanacDiagramTrackBelowHorizon(".almanac-diagram-track--sun", diagramData && diagramData["sun"] && diagramData["sun"]["altitude"]);
     setAlmanacDiagramTrackBelowHorizon(".almanac-diagram-track--moon", diagramData && diagramData["moon"] && diagramData["moon"]["altitude"]);
 
-    if (!jQuery(".almanac-diagram-track--sun, .almanac-diagram-track--moon").length) {
+    if (!document.querySelector(".almanac-diagram-track--sun, .almanac-diagram-track--moon")) {
         setAlmanacDiagramTrackBelowHorizon(".almanac-diagram-track", diagramData && diagramData["sun"] && diagramData["sun"]["altitude"]);
     }
 
@@ -1911,22 +1984,16 @@ function renderAlmanacDiagram(diagramData, preserveViewBox) {
 }
 
 function initializeAlmanacDiagramFromDOM() {
-    var diagram = jQuery(".almanac-diagram");
+    var diagram = document.querySelector(".almanac-diagram");
 
-    if (!diagram.length) {
+    if (!diagram) {
         return;
     }
 
     var readNumericAttr = function(attrName, dataKey) {
-        var attrRaw = diagram.attr(attrName);
-        var attrParsed = parseFloat(attrRaw);
+        var attrParsed = parseFloat(diagram.getAttribute(attrName));
         if (isFinite(attrParsed)) {
             return attrParsed;
-        }
-
-        var dataParsed = parseFloat(diagram.data(dataKey));
-        if (isFinite(dataParsed)) {
-            return dataParsed;
         }
 
         return null;
@@ -1948,7 +2015,7 @@ function initializeAlmanacDiagramFromDOM() {
             set_epoch: readNumericAttr("data-moon-set-epoch", "moonSetEpoch"),
             x_offset: readNumericAttr("data-moon-x-offset", "moonXOffset")
         },
-        centering_mode: String(diagram.attr("data-centering-mode") || diagram.data("centeringMode") || "off").toLowerCase(),
+        centering_mode: String(diagram.getAttribute("data-centering-mode") || "off").toLowerCase(),
         current_ts: readNumericAttr("data-current-ts", "currentTs"),
         current_x: readNumericAttr("data-current-x", "currentX")
     });
@@ -2092,38 +2159,51 @@ function changeTheme(themeName, toggleOverride = false) {
         sessionStorage.setItem('theme', 'toggleOverride');
         belchertown_debug("Theme: sessionStorage.getItem('theme') is now: " + sessionStorage.getItem('theme'));
     }
+    var logoImage = document.getElementById("logo_image");
     if (themeName == "dark") {
         // Apply dark theme: Bootstrap's native colour mode plus the skin's body class
         document.documentElement.setAttribute("data-bs-theme", "dark");
         // #if $radar_html_dark != "None"
-        jQuery('.radar_image').html('$radar_html_dark');
+        document.querySelectorAll('.radar_image').forEach(function(el) {
+            el.innerHTML = '$radar_html_dark';
+        });
         belchertown_schedule_deferred_iframes(document.querySelector(".radar_image"), 100);
         // #end if
-        jQuery('body').addClass("dark");
-        jQuery('body').removeClass("light");
+        document.body.classList.add("dark");
+        document.body.classList.remove("light");
         // #if $Extras.has_key('theme_toggle_enabled') and $Extras.theme_toggle_enabled == '1'
-        jQuery(".themeSwitchInput").prop("checked", true);
+        document.querySelectorAll(".themeSwitchInput").forEach(function(el) {
+            el.checked = true;
+        });
         // #end if
         // #if $Extras.has_key('logo_image_dark') and $Extras.logo_image_dark != ""
         belchertown_debug("Theme: logo_image_dark is defined.");
-        jQuery("#logo_image").attr("src", "$Extras.logo_image_dark");
+        if (logoImage) {
+            logoImage.src = "$Extras.logo_image_dark";
+        }
         // #end if
         sessionStorage.setItem('currentTheme', 'dark');
     } else if (themeName == "light") {
         // Apply light theme
         document.documentElement.setAttribute("data-bs-theme", "light");
         // #if $radar_html_dark != "None"
-        jQuery('.radar_image').html('$radar_html');
+        document.querySelectorAll('.radar_image').forEach(function(el) {
+            el.innerHTML = '$radar_html';
+        });
         belchertown_schedule_deferred_iframes(document.querySelector(".radar_image"), 100);
         // #end if
-        jQuery('body').addClass("light");
-        jQuery('body').removeClass("dark");
+        document.body.classList.add("light");
+        document.body.classList.remove("dark");
         // #if $Extras.has_key('theme_toggle_enabled') and $Extras.theme_toggle_enabled == '1'
-        jQuery(".themeSwitchInput").prop("checked", false);
+        document.querySelectorAll(".themeSwitchInput").forEach(function(el) {
+            el.checked = false;
+        });
         // #end if
         // #if $Extras.has_key('logo_image') and $Extras.logo_image != ""
         belchertown_debug("Theme: logo_image is defined.");
-        jQuery("#logo_image").attr("src", "$Extras.logo_image");
+        if (logoImage) {
+            logoImage.src = "$Extras.logo_image";
+        }
         // #end if
         sessionStorage.setItem('currentTheme', 'light');
     }
@@ -2163,7 +2243,7 @@ function formatAlmanacEpochTime(epoch, formatString, unavailableText) {
 }
 
 function enhanceAlmanacExtrasModal(almanacData) {
-    var modalBody = jQuery("#almanac-modal .almanac-extras-modal-body");
+    var modalBody = document.querySelector("#almanac-modal .almanac-extras-modal-body");
     var sourceRaw;
     var sourceLabel;
     var sourceNote;
@@ -2209,24 +2289,28 @@ function enhanceAlmanacExtrasModal(almanacData) {
         almanacTimeFormat = "LT";
     }
 
-    if (!modalBody.length) {
+    if (!modalBody) {
         return;
     }
 
     belchertown_decode_text_nodes(modalBody);
 
-    modalBody.find("table.celestial").each(function() {
-        var table = jQuery(this);
+    var rowCells = function(row, tagName) {
+        return Array.prototype.filter.call(row.children, function(cell) {
+            return cell.tagName === tagName;
+        });
+    };
 
-        table.find("tr").each(function() {
-            var row = jQuery(this);
-            var headerCells = row.children("th");
-            var cells = row.children("td");
+    modalBody.querySelectorAll("table.celestial").forEach(function(table) {
 
-            row.removeClass("celestial-row celestial-row--header celestial-row--item");
+        table.querySelectorAll("tr").forEach(function(row) {
+            var headerCells = rowCells(row, "TH");
+            var cells = rowCells(row, "TD");
+
+            row.classList.remove("celestial-row", "celestial-row--header", "celestial-row--item");
 
             if (headerCells.length) {
-                row.addClass("celestial-row celestial-row--header");
+                row.classList.add("celestial-row", "celestial-row--header");
                 return;
             }
 
@@ -2234,12 +2318,14 @@ function enhanceAlmanacExtrasModal(almanacData) {
                 return;
             }
 
-            cells.removeClass("celestial-cell-label celestial-cell-value");
+            cells.forEach(function(cell) {
+                cell.classList.remove("celestial-cell-label", "celestial-cell-value");
+            });
 
-            var labelCell = jQuery(cells[0]);
-            var valueCell = jQuery(cells[1]);
-            var labelText = labelCell.text().replace(/\u00a0/g, " ").trim();
-            var valueText = valueCell.text().replace(/\u00a0/g, " ").trim();
+            var labelCell = cells[0];
+            var valueCell = cells[1];
+            var labelText = labelCell.textContent.replace(/\u00a0/g, " ").trim();
+            var valueText = valueCell.textContent.replace(/\u00a0/g, " ").trim();
 
             // Remove spacer rows coming from legacy table formatting.
             if (!labelText && !valueText) {
@@ -2247,9 +2333,9 @@ function enhanceAlmanacExtrasModal(almanacData) {
                 return;
             }
 
-            row.addClass("celestial-row celestial-row--item");
-            labelCell.addClass("celestial-cell-label");
-            valueCell.addClass("celestial-cell-value");
+            row.classList.add("celestial-row", "celestial-row--item");
+            labelCell.classList.add("celestial-cell-label");
+            valueCell.classList.add("celestial-cell-value");
 
             // Localize date/time-like values independent of UI language.
             var looksLikeDateTime = /\d{1,4}[\/\-]\d{1,2}[\/\-]\d{1,4}/.test(valueText) && /\d{1,2}:\d{2}/.test(valueText);
@@ -2263,9 +2349,9 @@ function enhanceAlmanacExtrasModal(almanacData) {
                 if (parsed.isValid()) {
                     var formattedDateTime = parsed.locale(moment.locale()).format(almanacDateTimeFormat);
                     formattedDateTime = formattedDateTime.replace(/\s([AP]M)$/i, "\u00a0$1");
-                    valueCell.text(formattedDateTime);
+                    valueCell.textContent = formattedDateTime;
                 } else {
-                    valueCell.text(valueText.replace(/\s([AP]M)$/i, "\u00a0$1"));
+                    valueCell.textContent = valueText.replace(/\s([AP]M)$/i, "\u00a0$1");
                 }
             } else if (looksLikeTimeOnly && valueText && valueText !== "--") {
                 var parsedTime = moment(
@@ -2285,9 +2371,9 @@ function enhanceAlmanacExtrasModal(almanacData) {
                 if (parsedTime.isValid()) {
                     var formattedTime = parsedTime.locale(moment.locale()).format(almanacTimeFormat);
                     formattedTime = formattedTime.replace(/\s([AP]M)$/i, "\u00a0$1");
-                    valueCell.text(formattedTime);
+                    valueCell.textContent = formattedTime;
                 } else {
-                    valueCell.text(valueText.replace(/\s([AP]M)$/i, "\u00a0$1"));
+                    valueCell.textContent = valueText.replace(/\s([AP]M)$/i, "\u00a0$1");
                 }
             }
         });
@@ -2300,34 +2386,40 @@ function enhanceAlmanacExtrasModal(almanacData) {
         moonAgeValue = belchertown_decode_html_entities(weewx_data["almanac"]["moon"]["moon_age"]).replace(/\u00a0/g, " ").trim();
     }
     if (moonAgeValue && moonAgeValue !== "--") {
-        var moonTable = modalBody.find("table.celestial").eq(1);
-        if (moonTable.length) {
-            var moonAgeRow = moonTable.find("tr[data-row='moon-age']").first();
-            if (!moonAgeRow.length) {
-                moonAgeRow = jQuery("<tr class='celestial-row celestial-row--item' data-row='moon-age'><td class='label celestial-cell-label'></td><td class='data celestial-cell-value'></td></tr>");
-                moonAgeRow.find("td").eq(0).text(moonAgeLabel);
+        var moonTable = modalBody.querySelectorAll("table.celestial")[1];
+        if (moonTable) {
+            var moonAgeRow = moonTable.querySelector("tr[data-row='moon-age']");
+            if (!moonAgeRow) {
+                moonAgeRow = document.createElement("tr");
+                moonAgeRow.className = "celestial-row celestial-row--item";
+                moonAgeRow.setAttribute("data-row", "moon-age");
+                moonAgeRow.innerHTML = "<td class='label celestial-cell-label'></td><td class='data celestial-cell-value'></td>";
+                moonAgeRow.children[0].textContent = moonAgeLabel;
 
-                var phaseRow = jQuery();
-                moonTable.find("tr").each(function() {
-                    var row = jQuery(this);
-                    var tds = row.children("td");
+                var phaseRow = null;
+                var moonRows = moonTable.querySelectorAll("tr");
+                for (var ri = 0; ri < moonRows.length; ri++) {
+                    var tds = rowCells(moonRows[ri], "TD");
                     if (tds.length >= 2) {
-                        var lbl = jQuery(tds[0]).text().replace(/\u00a0/g, " ").trim().toLowerCase();
+                        var lbl = tds[0].textContent.replace(/\u00a0/g, " ").trim().toLowerCase();
                         if (lbl === phaseLabel || lbl.indexOf(phaseLabel) !== -1) {
-                            phaseRow = row;
-                            return false;
+                            phaseRow = moonRows[ri];
+                            break;
                         }
                     }
-                });
+                }
 
-                if (phaseRow.length) {
-                    moonAgeRow.insertBefore(phaseRow);
+                if (phaseRow) {
+                    phaseRow.parentNode.insertBefore(moonAgeRow, phaseRow);
                 } else {
-                    moonTable.append(moonAgeRow);
+                    (moonTable.tBodies[0] || moonTable).appendChild(moonAgeRow);
                 }
             }
 
-            moonAgeRow.find("td").eq(1).text(moonAgeValue);
+            var moonAgeCells = moonAgeRow.querySelectorAll("td");
+            if (moonAgeCells.length > 1) {
+                moonAgeCells[1].textContent = moonAgeValue;
+            }
         }
     }
 
@@ -2374,43 +2466,45 @@ function enhanceAlmanacExtrasModal(almanacData) {
         sourceLabel = sourceNoneLabel;
     }
 
-    sourceNote = modalBody.find(".celestial_source_note").first();
-    if (!sourceNote.length) {
-        sourceNote = jQuery('<div class="celestial_source_note"><small></small></div>');
+    sourceNote = modalBody.querySelector(".celestial_source_note");
+    if (!sourceNote) {
+        sourceNote = document.createElement("div");
+        sourceNote.className = "celestial_source_note";
+        sourceNote.appendChild(document.createElement("small"));
     }
 
-    sourceNoteSmall = sourceNote.find("small");
-    if (!sourceNoteSmall.length) {
-        sourceNoteSmall = jQuery("<small></small>");
-        sourceNote.empty().append(sourceNoteSmall);
+    sourceNoteSmall = sourceNote.querySelector("small");
+    if (!sourceNoteSmall) {
+        sourceNoteSmall = document.createElement("small");
+        sourceNote.innerHTML = "";
+        sourceNote.appendChild(sourceNoteSmall);
     }
-    sourceNoteSmall.html(
+    sourceNoteSmall.innerHTML = (
         belchertown_escape_html(dataSourceLabel) +
         ": <strong>" +
         belchertown_escape_html(sourceLabel) +
         "</strong>"
     );
 
-    detailsContainer = modalBody.find("#celestial_details").first();
-    if (detailsContainer.length) {
-        detailsContainer.append(sourceNote);
+    detailsContainer = modalBody.querySelector("#celestial_details");
+    if (detailsContainer) {
+        detailsContainer.appendChild(sourceNote);
     } else {
-        modalBody.append(sourceNote);
+        modalBody.appendChild(sourceNote);
     }
 
     // If total daylight remained '--', compute a local fallback from sunrise/sunset.
     daylightValue = null;
-    modalBody.find("table.celestial tr").each(function() {
-        var row = jQuery(this);
-        var tds = row.children("td");
+    modalBody.querySelectorAll("table.celestial tr").forEach(function(row) {
+        var tds = rowCells(row, "TD");
         if (tds.length >= 2) {
-            var lbl = jQuery(tds[0]).text().replace(/\u00a0/g, " ").trim().toLowerCase();
+            var lbl = tds[0].textContent.replace(/\u00a0/g, " ").trim().toLowerCase();
             if (lbl === totalDaylightLabel || lbl.indexOf(totalDaylightLabel) !== -1) {
-                daylightValue = jQuery(tds[1]);
+                daylightValue = tds[1];
             }
         }
     });
-    if (daylightValue && daylightValue.text().replace(/\u00a0/g, " ").trim() === "--") {
+    if (daylightValue && daylightValue.textContent.replace(/\u00a0/g, " ").trim() === "--") {
         sunriseEpoch = parseFloat(almanacData && almanacData["sunrise_epoch"]);
         sunsetEpoch = parseFloat(almanacData && almanacData["sunset_epoch"]);
         if (isFinite(sunriseEpoch) && isFinite(sunsetEpoch) && sunsetEpoch >= sunriseEpoch) {
@@ -2418,7 +2512,7 @@ function enhanceAlmanacExtrasModal(almanacData) {
             var hours = Math.floor(total / 3600);
             var mins = Math.floor((total % 3600) / 60);
             var secs = total % 60;
-            daylightValue.text(hours + hourShort + " " + mins + minuteShort + " " + secs + secondShort);
+            daylightValue.textContent = hours + hourShort + " " + mins + minuteShort + " " + secs + secondShort;
         }
     }
 }
@@ -2448,47 +2542,47 @@ function formatSnapshotMetricValue(value) {
 function updateDailySnapshot(data, key) {
     var d = data[key];
     if (!d) return;
-    jQuery(".dailystatshigh").html(formatSnapshotMetricValue(getNestedValue(d, ["outTemp", "max"])));
-    jQuery(".dailystatslow").html(formatSnapshotMetricValue(getNestedValue(d, ["outTemp", "min"])));
-    jQuery(".dailystatswindavg").html(formatSnapshotMetricValue(getNestedValue(d, ["wind", "average"])));
-    jQuery(".dailystatswindmax").html(formatSnapshotMetricValue(getNestedValue(d, ["wind", "max"])));
-    jQuery(".dailystatsrain").html(formatSnapshotMetricValue(getNestedValue(d, ["rain", "sum"])));
-    jQuery(".dailystatsrainrate").html(formatSnapshotMetricValue(getNestedValue(d, ["rain", "max"])));
-    jQuery(".dailystatsuvavg").html(formatSnapshotMetricValue(getNestedValue(d, ["uv", "average"])));
-    jQuery(".dailystatsuvmax").html(formatSnapshotMetricValue(getNestedValue(d, ["uv", "max"])));
-    jQuery(".dailystatsradiationavg").html(formatSnapshotMetricValue(getNestedValue(d, ["solar_radiation", "average"])));
-    jQuery(".dailystatsradiationmax").html(formatSnapshotMetricValue(getNestedValue(d, ["solar_radiation", "max"])));
-    jQuery(".dailystatssunshineDur").html(formatSnapshotMetricValue(getNestedValue(d, ["sunshineDur", "sum"])));
+    belchertown_set_html(".dailystatshigh", formatSnapshotMetricValue(getNestedValue(d, ["outTemp", "max"])));
+    belchertown_set_html(".dailystatslow", formatSnapshotMetricValue(getNestedValue(d, ["outTemp", "min"])));
+    belchertown_set_html(".dailystatswindavg", formatSnapshotMetricValue(getNestedValue(d, ["wind", "average"])));
+    belchertown_set_html(".dailystatswindmax", formatSnapshotMetricValue(getNestedValue(d, ["wind", "max"])));
+    belchertown_set_html(".dailystatsrain", formatSnapshotMetricValue(getNestedValue(d, ["rain", "sum"])));
+    belchertown_set_html(".dailystatsrainrate", formatSnapshotMetricValue(getNestedValue(d, ["rain", "max"])));
+    belchertown_set_html(".dailystatsuvavg", formatSnapshotMetricValue(getNestedValue(d, ["uv", "average"])));
+    belchertown_set_html(".dailystatsuvmax", formatSnapshotMetricValue(getNestedValue(d, ["uv", "max"])));
+    belchertown_set_html(".dailystatsradiationavg", formatSnapshotMetricValue(getNestedValue(d, ["solar_radiation", "average"])));
+    belchertown_set_html(".dailystatsradiationmax", formatSnapshotMetricValue(getNestedValue(d, ["solar_radiation", "max"])));
+    belchertown_set_html(".dailystatssunshineDur", formatSnapshotMetricValue(getNestedValue(d, ["sunshineDur", "sum"])));
     if (d["wind"] && d["wind"]["windrun"]) {
-        jQuery(".dailywindrun").html(formatSnapshotMetricValue(d["wind"]["windrun"]));
+        belchertown_set_html(".dailywindrun", formatSnapshotMetricValue(d["wind"]["windrun"]));
     }
 }
 
 function updateMonthlySnapshot(data, key) {
     var d = data[key];
     if (!d) return;
-    jQuery(".monthstatshigh").html(formatSnapshotMetricValue(getNestedValue(d, ["outTemp", "max"])));
-    jQuery(".monthstatslow").html(formatSnapshotMetricValue(getNestedValue(d, ["outTemp", "min"])));
-    jQuery(".monthstatswindavg").html(formatSnapshotMetricValue(getNestedValue(d, ["wind", "average"])));
-    jQuery(".monthstatswindmax").html(formatSnapshotMetricValue(getNestedValue(d, ["wind", "max"])));
-    jQuery(".monthstatsrain").html(formatSnapshotMetricValue(getNestedValue(d, ["rain", "sum"])));
-    jQuery(".monthstatsrainrate").html(formatSnapshotMetricValue(getNestedValue(d, ["rain", "max"])));
-    jQuery(".monthstatsuvavg").html(formatSnapshotMetricValue(getNestedValue(d, ["uv", "average"])));
-    jQuery(".monthstatsuvmax").html(formatSnapshotMetricValue(getNestedValue(d, ["uv", "max"])));
-    jQuery(".monthstatsradiationavg").html(formatSnapshotMetricValue(getNestedValue(d, ["solar_radiation", "average"])));
-    jQuery(".monthstatsradiationmax").html(formatSnapshotMetricValue(getNestedValue(d, ["solar_radiation", "max"])));
-    jQuery(".monthstatssunshineDur").html(formatSnapshotMetricValue(getNestedValue(d, ["sunshineDur", "sum"])));
+    belchertown_set_html(".monthstatshigh", formatSnapshotMetricValue(getNestedValue(d, ["outTemp", "max"])));
+    belchertown_set_html(".monthstatslow", formatSnapshotMetricValue(getNestedValue(d, ["outTemp", "min"])));
+    belchertown_set_html(".monthstatswindavg", formatSnapshotMetricValue(getNestedValue(d, ["wind", "average"])));
+    belchertown_set_html(".monthstatswindmax", formatSnapshotMetricValue(getNestedValue(d, ["wind", "max"])));
+    belchertown_set_html(".monthstatsrain", formatSnapshotMetricValue(getNestedValue(d, ["rain", "sum"])));
+    belchertown_set_html(".monthstatsrainrate", formatSnapshotMetricValue(getNestedValue(d, ["rain", "max"])));
+    belchertown_set_html(".monthstatsuvavg", formatSnapshotMetricValue(getNestedValue(d, ["uv", "average"])));
+    belchertown_set_html(".monthstatsuvmax", formatSnapshotMetricValue(getNestedValue(d, ["uv", "max"])));
+    belchertown_set_html(".monthstatsradiationavg", formatSnapshotMetricValue(getNestedValue(d, ["solar_radiation", "average"])));
+    belchertown_set_html(".monthstatsradiationmax", formatSnapshotMetricValue(getNestedValue(d, ["solar_radiation", "max"])));
+    belchertown_set_html(".monthstatssunshineDur", formatSnapshotMetricValue(getNestedValue(d, ["sunshineDur", "sum"])));
 }
 
-jQuery(document).on("change", "#snapshot-day-select", function() {
-    if (weewx_data) {
-        updateDailySnapshot(weewx_data, jQuery(this).val());
+document.addEventListener("change", function(event) {
+    var daySelect = event.target.closest("#snapshot-day-select");
+    if (daySelect && weewx_data) {
+        updateDailySnapshot(weewx_data, daySelect.value);
+        return;
     }
-});
-
-jQuery(document).on("change", "#snapshot-month-select", function() {
-    if (weewx_data) {
-        updateMonthlySnapshot(weewx_data, jQuery(this).val());
+    var monthSelect = event.target.closest("#snapshot-month-select");
+    if (monthSelect && weewx_data) {
+        updateMonthlySnapshot(weewx_data, monthSelect.value);
     }
 });
 
@@ -2508,8 +2602,8 @@ function update_weewx_data(data) {
     // Daily High Low
     high = data["day"]["outTemp"]["max"];
     low = data["day"]["outTemp"]["min"];
-    jQuery(".high").html(high);
-    jQuery(".low").html(low);
+    belchertown_set_html(".high", high);
+    belchertown_set_html(".low", low);
 
     try {
         // Barometer trending by finding a negative number
@@ -2519,32 +2613,34 @@ function update_weewx_data(data) {
     }
 
     if (count >= 1) {
-        jQuery(".pressure-trend").html('<i class="fa fa-arrow-down barometer-down"></i>');
+        belchertown_set_html(".pressure-trend", '<i class="fa fa-arrow-down barometer-down"></i>');
     } else {
-        jQuery(".pressure-trend").html('<i class="fa fa-arrow-up barometer-up"></i>');
+        belchertown_set_html(".pressure-trend", '<i class="fa fa-arrow-up barometer-up"></i>');
     }
 
     // Daily max gust span
-    jQuery(".dailymaxgust").html(parseFloat(data["day"]["wind"]["max"]).toFixed(1));
+    belchertown_set_html(".dailymaxgust", parseFloat(data["day"]["wind"]["max"]).toFixed(1));
 
     // Daily Snapshot Stats Section — use current dropdown selection (default: "day")
-    var dayKey = jQuery("#snapshot-day-select").val() || "day";
+    var daySelectEl = document.getElementById("snapshot-day-select");
+    var dayKey = (daySelectEl && daySelectEl.value) || "day";
     updateDailySnapshot(data, dayKey);
 
     // Month Snapshot Stats Section — use current dropdown selection (default: "month")
-    var monthKey = jQuery("#snapshot-month-select").val() || "month";
+    var monthSelectEl = document.getElementById("snapshot-month-select");
+    var monthKey = (monthSelectEl && monthSelectEl.value) || "month";
     updateMonthlySnapshot(data, monthKey);
 
     // Sunrise, sunset, moonrise and moonset
-    jQuery(".sunrise-value").text(formatAlmanacEpochTime(data["almanac"]["sunrise_epoch"], belchertown_label_text("$obs.label.time_sunrise"), data["almanac"]["sunrise"] || "N/A"));
-    jQuery(".sunset-value").text(formatAlmanacEpochTime(data["almanac"]["sunset_epoch"], belchertown_label_text("$obs.label.time_sunset"), data["almanac"]["sunset"] || "N/A"));
-    jQuery(".moonrise-value").text(formatAlmanacEpochTime(data["almanac"]["moon"]["moon_rise_epoch"], belchertown_label_text("$obs.label.time_sunrise"), data["almanac"]["moon"]["moon_rise"] || "N/A"));
-    jQuery(".moonset-value").text(formatAlmanacEpochTime(data["almanac"]["moon"]["moon_set_epoch"], belchertown_label_text("$obs.label.time_sunrise"), data["almanac"]["moon"]["moon_set"] || "N/A"));
+    belchertown_set_text(".sunrise-value", formatAlmanacEpochTime(data["almanac"]["sunrise_epoch"], belchertown_label_text("$obs.label.time_sunrise"), data["almanac"]["sunrise"] || "N/A"));
+    belchertown_set_text(".sunset-value", formatAlmanacEpochTime(data["almanac"]["sunset_epoch"], belchertown_label_text("$obs.label.time_sunset"), data["almanac"]["sunset"] || "N/A"));
+    belchertown_set_text(".moonrise-value", formatAlmanacEpochTime(data["almanac"]["moon"]["moon_rise_epoch"], belchertown_label_text("$obs.label.time_sunrise"), data["almanac"]["moon"]["moon_rise"] || "N/A"));
+    belchertown_set_text(".moonset-value", formatAlmanacEpochTime(data["almanac"]["moon"]["moon_set_epoch"], belchertown_label_text("$obs.label.time_sunrise"), data["almanac"]["moon"]["moon_set"] || "N/A"));
 
     // Moon icon, phase and illumination percent
-    jQuery(".moon-container > .moon-icon").html(render_moon_icon_html(data));
-    jQuery(".moon-phase").text(titleCase(data["almanac"]["moon"]["moon_phase"])); // Javascript function above
-    jQuery(".moon-visible").html("<strong>" + belchertown_escape_html(data["almanac"]["moon"]["moon_fullness"]) + "%</strong> " + belchertown_label_html("$obs.label.moon_visible"));
+    belchertown_set_html(".moon-container > .moon-icon", render_moon_icon_html(data));
+    belchertown_set_text(".moon-phase", titleCase(data["almanac"]["moon"]["moon_phase"])); // Javascript function above
+    belchertown_set_html(".moon-visible", "<strong>" + belchertown_escape_html(data["almanac"]["moon"]["moon_fullness"]) + "%</strong> " + belchertown_label_html("$obs.label.moon_visible"));
 
     // Do not synthesize daylight text in JS. Keep server-rendered daylight
     // string authoritative (includes change-vs-yesterday when available).
@@ -2552,17 +2648,18 @@ function update_weewx_data(data) {
     renderAlmanacDiagram(data["almanac"]["diagram"]);
     // #if $almanac.hasExtras
     // Close current modal if open
-    if (jQuery.fn.modal && jQuery('#almanac-modal').length) {
-        jQuery('#almanac-modal').modal('hide');
+    var almanacModalToHide = document.getElementById('almanac-modal');
+    if (almanacModalToHide && typeof bootstrap !== "undefined" && bootstrap.Modal) {
+        bootstrap.Modal.getOrCreateInstance(almanacModalToHide).hide();
     }
     if (data["almanac"] && typeof data["almanac"]["almanac_extras_modal_html"] === "string" && data["almanac"]["almanac_extras_modal_html"].length > 0) {
-        jQuery(".almanac-extras-modal-body").html(data["almanac"]["almanac_extras_modal_html"]);
-        belchertown_decode_text_nodes(jQuery(".almanac-extras-modal-body"));
+        belchertown_set_html(".almanac-extras-modal-body", data["almanac"]["almanac_extras_modal_html"]);
+        belchertown_decode_text_nodes(document.querySelector(".almanac-extras-modal-body"));
     }
     enhanceAlmanacExtrasModal(data["almanac"]);
     try {
         almanac_updated = belchertown_label_text("$obs.label.header_last_updated") + " " + tzAdjustedMoment(data["current"]["datetime_raw"]).format(belchertown_label_text("$obs.label.time_last_updated"));
-        jQuery(".almanac_last_updated").text(almanac_updated);
+        belchertown_set_text(".almanac_last_updated", almanac_updated);
     } catch (err) {
         // Returned "current" data does not have this value
     }
@@ -2653,7 +2750,7 @@ function render_oriented_moon_svg(illuminationFraction, waxing, orientationDeg) 
     var litPath = moon_illuminated_path(illuminationFraction, waxing, cx, cy, r);
     var litFillRule = illuminationFraction > 0.5 && illuminationFraction < 1 ? "evenodd" : "nonzero";
 
-    var isDarkTheme = jQuery("body").hasClass("dark") || sessionStorage.getItem('currentTheme') === 'dark';
+    var isDarkTheme = document.body.classList.contains("dark") || sessionStorage.getItem('currentTheme') === 'dark';
     var moonDark = isDarkTheme ? "#6b7280" : "#8b95a5";
     var moonLight = isDarkTheme ? "#e5ebf7" : "#f6f8fc";
     var moonEdge = isDarkTheme ? "#cbd5e1" : "#6b7280";
@@ -2772,7 +2869,9 @@ window.addEventListener("resize", forecast_sync_row_height);
 //  function to display selected forecast according to value of interval (1, 3 or 24); 0 hides all forecasts
 function forecast_select(interval) {
     if (interval == 0) {
-        jQuery(".forecastrow").hide();
+        document.querySelectorAll(".forecastrow").forEach(function(el) {
+            el.style.display = "none";
+        });
     } else {
         forecast_sync_row_height();
         oldinterval = sessionStorage.getItem("forecastInterval");

--- a/skins/new-belchertown/kiosk.html.tmpl
+++ b/skins/new-belchertown/kiosk.html.tmpl
@@ -50,15 +50,15 @@
         setTimeout(autoRefreshPage, $Extras.webpage_autorefresh);
         // #end if
 
-        jQuery(document).ready(function() {
+        belchertown_on_ready(function() {
             // #if $Extras.has_key("aqi_enabled_kiosk") and $Extras.aqi_enabled_kiosk == '1'
             get_aqi_color("$aqi");
             // #end if
 
             // #if $Extras.has_key("beaufort_category") and $Extras.beaufort_category == '1' and $Extras.beaufort_category_gusts != '1'
-            jQuery(".beaufort").html(beaufort_cat(kts_to_beaufort("$current.windSpeed.knot.toString(addLabel=False, NONE_string='')")));
+            belchertown_set_html(".beaufort", beaufort_cat(kts_to_beaufort("$current.windSpeed.knot.toString(addLabel=False, NONE_string='')")));
             // #else
-            jQuery(".beaufort").html(beaufort_cat(kts_to_beaufort("$current.windGust.knot.toString(addLabel=False, NONE_string='')")));
+            belchertown_set_html(".beaufort", beaufort_cat(kts_to_beaufort("$current.windGust.knot.toString(addLabel=False, NONE_string='')")));
             // #end if
 
             get_outTemp_color("$unit.unit_type.outTemp", "$current.outTemp.formatted");
@@ -72,14 +72,14 @@
             // Update the Last Updated timestamp with moment.js,
             updated = tzAdjustedMoment($current.dateTime.raw).format(belchertown_label_text("$obs.label.time_last_updated"));
             updated_text = belchertown_label_text("$obs.label.header_last_updated") + " " + updated;
-            jQuery(".updated").text(updated_text);
+            belchertown_set_text(".updated", updated_text);
 
             // #if $Extras.has_key('earthquake_enabled') and $Extras.earthquake_enabled == '1'
             if (moment.unix("$earthquake_time").isValid()) {
                 // Check that the time is the time (number) and not the "no earthquake available" wording
-                jQuery(".earthquake-time").text(tzAdjustedMoment("$earthquake_time").format(belchertown_label_text("$obs.label.time_earthquake")));
+                belchertown_set_text(".earthquake-time", tzAdjustedMoment("$earthquake_time").format(belchertown_label_text("$obs.label.time_earthquake")));
             } else {
-                jQuery(".earthquake-time").text(belchertown_label_text("$earthquake_time"));
+                belchertown_set_text(".earthquake-time", belchertown_label_text("$earthquake_time"));
             }
             // #end if
 
@@ -129,15 +129,15 @@
             if ((Math.floor(new Date().getTime() / 1000.0) - $Extras.last_updated_alert_threshold) > $current.dateTime.raw) {
                 belchertown_debug("Last Updated Alert: The WeeWX report timestamp is " + $current.dateTime.raw + ". The current timestamp is " + Math.floor(new Date().getTime() / 1000.0) + ". The threshold is " + $Extras.last_updated_alert_threshold + ". Report timestamp is greater than threshold of current time, showing no update alert.");
                 last_updated_alert_text = "<i class='fa fa-exclamation-triangle' style='color:red;'></i> " + belchertown_label_html("$obs.label.header_last_updated_alert");
-                jQuery(".last-updated-alert").html(last_updated_alert_text);
-                jQuery(".last-updated-alert").show();
+                belchertown_set_html(".last-updated-alert", last_updated_alert_text);
+                document.querySelectorAll(".last-updated-alert").forEach(function(el) { el.style.display = ""; });
             }
             // #end if
 
             // Update the Last Updated timestamp with moment.js,
             updated = tzAdjustedMoment($current.dateTime.raw).format(belchertown_label_text("$obs.label.time_last_updated"));
             updated_text = belchertown_label_text("$obs.label.header_last_updated") + " " + updated;
-            jQuery(".updated").text(updated_text);
+            belchertown_set_text(".updated", updated_text);
 
             // #end if
 

--- a/skins/new-belchertown/pi/index.html.tmpl
+++ b/skins/new-belchertown/pi/index.html.tmpl
@@ -33,7 +33,7 @@
     ajaxforecast(); // Initial call to load forecast data like 8 day outlook, weather icon and observation text
     // #end if
 
-    jQuery(document).ready(function() {
+    belchertown_on_ready(function() {
         get_outTemp_color("$unit.unit_type.outTemp", "$current.outTemp.formatted");
 
         initialize_wind_compass_marker(
@@ -48,7 +48,7 @@
         // Update the Last Updated timestamp with moment.js,
         updated = tzAdjustedMoment($current.dateTime.raw).format(belchertown_label_text("$obs.label.time_last_updated"));
         updated_text = belchertown_label_text("$obs.label.header_last_updated") + " " + updated;
-        jQuery(".updated").text(updated_text);
+        belchertown_set_text(".updated", updated_text);
 
         // #end if
     });

--- a/skins/new-belchertown/records/index.html.tmpl
+++ b/skins/new-belchertown/records/index.html.tmpl
@@ -41,6 +41,30 @@
             return decodeHtmlEntities(String(value || ""));
         }
 
+        function belchertown_trim(value) {
+            return value == null ? "" : String(value).trim();
+        }
+
+        function buildElementFromHtml(html) {
+            var wrapper = document.createElement("div");
+            wrapper.innerHTML = html;
+            return wrapper.firstElementChild;
+        }
+
+        function setElementText(root, selector, text) {
+            var el = root.querySelector(selector);
+            if (el) {
+                el.textContent = text;
+            }
+        }
+
+        function setElementHtml(root, selector, html) {
+            var el = root.querySelector(selector);
+            if (el) {
+                el.innerHTML = html;
+            }
+        }
+
         function escapeHtml(value) {
             return displayText(value)
                 .replace(/&/g, "&amp;")
@@ -379,16 +403,16 @@
         }
 
         function updateSectionPeriodHeader(section, labels) {
-            if (!section || !section.length) {
+            if (!section) {
                 return;
             }
 
-            section.find(".records-section-card__period-header-cell--day").text(displayText("$obs.label.snapshot_period_day"));
-            section.find(".records-section-card__period-header-cell--yesterday").text(displayText("$obs.label.snapshot_period_yesterday"));
-            section.find(".records-section-card__period-header-cell--week").text(displayText("$obs.label.snapshot_period_7days"));
-            section.find(".records-section-card__period-header-cell--month").text(displayText("$obs.label.snapshot_period_month"));
-            section.find(".records-section-card__period-header-cell--year").text(displayText(labels.year || ""));
-            section.find(".records-section-card__period-header-cell--alltime").text(displayText(labels.alltime || "$obs.label.records_all_time"));
+            setElementText(section, ".records-section-card__period-header-cell--day", displayText("$obs.label.snapshot_period_day"));
+            setElementText(section, ".records-section-card__period-header-cell--yesterday", displayText("$obs.label.snapshot_period_yesterday"));
+            setElementText(section, ".records-section-card__period-header-cell--week", displayText("$obs.label.snapshot_period_7days"));
+            setElementText(section, ".records-section-card__period-header-cell--month", displayText("$obs.label.snapshot_period_month"));
+            setElementText(section, ".records-section-card__period-header-cell--year", displayText(labels.year || ""));
+            setElementText(section, ".records-section-card__period-header-cell--alltime", displayText(labels.alltime || "$obs.label.records_all_time"));
         }
 
         function snapshotMetric(periodData, metricDef) {
@@ -407,16 +431,16 @@
             }
 
             return {
-                value: jQuery.trim(displayText(value)),
-                dateText: jQuery.trim(displayText(groupData[metricDef.timeKey] || "--")) || "--",
+                value: belchertown_trim(displayText(value)),
+                dateText: belchertown_trim(displayText(groupData[metricDef.timeKey] || "--")) || "--",
                 dateRaw: metricDef.rawKey ? groupData[metricDef.rawKey] : null,
                 valueDetail: null
             };
         }
 
         function formatValueHtml(valueText, valueDetailText) {
-            var mainValue = jQuery.trim(String(valueText || "--")) || "--";
-            var detailValue = jQuery.trim(String(valueDetailText || ""));
+            var mainValue = belchertown_trim(String(valueText || "--")) || "--";
+            var detailValue = belchertown_trim(String(valueDetailText || ""));
             var html = '<span class="records-record-period__value-main">' + escapeHtml(mainValue) + '</span>';
 
             if (detailValue) {
@@ -427,7 +451,7 @@
         }
 
         function parseSnapshotMoment(dateRaw, dateText) {
-            var rawText = jQuery.trim(String(dateRaw || ""));
+            var rawText = belchertown_trim(String(dateRaw || ""));
             if (rawText && /^\d+(\.\d+)?$/.test(rawText)) {
                 var raw = parseFloat(rawText);
                 if (isFinite(raw) && raw > 0) {
@@ -435,7 +459,7 @@
                 }
             }
 
-            var text = jQuery.trim(displayText(dateText || ""));
+            var text = belchertown_trim(displayText(dateText || ""));
             if (!text || text === "--") {
                 return null;
             }
@@ -461,7 +485,7 @@
         }
 
         function splitDateNote(text) {
-            var rawText = jQuery.trim(displayText(text || ""));
+            var rawText = belchertown_trim(displayText(text || ""));
             if (!rawText) {
                 return { primary: "", secondary: "" };
             }
@@ -469,8 +493,8 @@
             var noteStart = rawText.indexOf("(");
             if (noteStart > 0) {
                 return {
-                    primary: jQuery.trim(rawText.substring(0, noteStart)),
-                    secondary: jQuery.trim(rawText.substring(noteStart).replace(/^\(|\)$/g, ""))
+                    primary: belchertown_trim(rawText.substring(0, noteStart)),
+                    secondary: belchertown_trim(rawText.substring(noteStart).replace(/^\(|\)$/g, ""))
                 };
             }
 
@@ -487,7 +511,7 @@
             var parsed = parseSnapshotMoment(dateRaw, dateText);
 
             if (rowOptions.omitTime) {
-                var sourceText = jQuery.trim(displayText(dateText || ""));
+                var sourceText = belchertown_trim(displayText(dateText || ""));
                 var dateLine = "";
 
                 if (/^\d{4}$/.test(sourceText)) {
@@ -536,7 +560,7 @@
                        '<span class="records-record-period__time-line">' + escapeHtml(timeLine) + '</span>';
             }
 
-            var text = jQuery.trim(displayText(dateText || ""));
+            var text = belchertown_trim(displayText(dateText || ""));
             if (!text || text === "--") {
                 return '<span class="records-record-period__date-line">--</span>';
             }
@@ -576,18 +600,15 @@
         function applyPeriod(recordCard, periodClass, labelText, periodKey, periodData, metricDef, fallback, rowOptions) {
             var options = rowOptions || {};
             var blankPeriods = options.blankPeriods || [];
-            if (blankPeriods.indexOf(periodKey) !== -1) {
-                recordCard.find(periodClass + " .records-record-period__label").text(displayText(labelText));
-                recordCard.find(periodClass + " .records-record-period__value").html(formatValueHtml("--", ""));
-                recordCard.find(periodClass + " .records-record-period__date").removeClass("records-record-period__date--prefixed").html('<span class="records-record-period__date-line">--</span>');
-                return;
-            }
-
             var dashPeriods = options.dashPeriods || [];
-            if (dashPeriods.indexOf(periodKey) !== -1) {
-                recordCard.find(periodClass + " .records-record-period__label").text(displayText(labelText));
-                recordCard.find(periodClass + " .records-record-period__value").html(formatValueHtml("--", ""));
-                recordCard.find(periodClass + " .records-record-period__date").removeClass("records-record-period__date--prefixed").html('<span class="records-record-period__date-line">--</span>');
+            if (blankPeriods.indexOf(periodKey) !== -1 || dashPeriods.indexOf(periodKey) !== -1) {
+                setElementText(recordCard, periodClass + " .records-record-period__label", displayText(labelText));
+                setElementHtml(recordCard, periodClass + " .records-record-period__value", formatValueHtml("--", ""));
+                var blankDateElement = recordCard.querySelector(periodClass + " .records-record-period__date");
+                if (blankDateElement) {
+                    blankDateElement.classList.remove("records-record-period__date--prefixed");
+                    blankDateElement.innerHTML = '<span class="records-record-period__date-line">--</span>';
+                }
                 return;
             }
 
@@ -604,29 +625,27 @@
             var dateRaw = resolved.dateRaw;
             var formattedDateHtml = formatSnapshotDateHtml(dateRaw, dateText, periodKey, rowOptions);
             var formattedValueHtml = formatValueHtml(valueText, valueDetailText);
-            var dateElement = recordCard.find(periodClass + " .records-record-period__date");
+            var dateElement = recordCard.querySelector(periodClass + " .records-record-period__date");
 
-            recordCard.find(periodClass + " .records-record-period__label").text(displayText(labelText));
-            recordCard.find(periodClass + " .records-record-period__value").html(formattedValueHtml);
-            if (rowOptions && rowOptions.datePrefix) {
-                dateElement.addClass("records-record-period__date--prefixed");
-            } else {
-                dateElement.removeClass("records-record-period__date--prefixed");
+            setElementText(recordCard, periodClass + " .records-record-period__label", displayText(labelText));
+            setElementHtml(recordCard, periodClass + " .records-record-period__value", formattedValueHtml);
+            if (dateElement) {
+                dateElement.classList.toggle("records-record-period__date--prefixed", !!(rowOptions && rowOptions.datePrefix));
+                dateElement.innerHTML = formattedDateHtml;
             }
-            dateElement.html(formattedDateHtml);
         }
 
-        var sectionsContainer = jQuery("#records-sections");
-        if (!sectionsContainer.length) {
+        var sectionsContainer = document.getElementById("records-sections");
+        if (!sectionsContainer) {
             return;
         }
 
-        sectionsContainer.empty();
+        sectionsContainer.innerHTML = "";
 
         var sections = getRecordsSectionsConfig();
 
         sections.forEach(function(sectionConfig) {
-            var section = jQuery(
+            var section = buildElementFromHtml(
                     '<section class="records-section-card">' +
                         '<div class="records-section-card__header">' +
                             '<h2 class="records-section-card__title"></h2>' +
@@ -645,18 +664,18 @@
                         '</div>' +
                     '</section>'
                 );
-            section.find(".records-section-card__title").text(displayText(sectionConfig.title));
+            setElementText(section, ".records-section-card__title", displayText(sectionConfig.title));
             updateSectionPeriodHeader(section, {
                 year: sectionConfig.yearLabel,
                 alltime: sectionConfig.alltimeLabel
             });
 
-            var sectionBody = section.find(".records-section-card__body");
+            var sectionBody = section.querySelector(".records-section-card__body");
 
             sectionConfig.rows.forEach(function(rowConfig) {
                 var recordTitle = displayText(rowConfig.label);
 
-                var recordCard = jQuery(
+                var recordCard = buildElementFromHtml(
                 '<article class="records-record-card">' +
                     '<h3 class="records-record-card__title"></h3>' +
                     '<section class="records-record-period records-record-period--day">' +
@@ -692,19 +711,19 @@
                 '</article>'
             );
 
-                recordCard.find(".records-record-card__title").text(recordTitle);
+                setElementText(recordCard, ".records-record-card__title", recordTitle);
 
-                var yearValueText = jQuery.trim(displayText(rowConfig.year.value || "--")) || "--";
-                var yearValueDetailText = jQuery.trim(displayText(rowConfig.year.valueDetail || ""));
-                var yearDateText = jQuery.trim(displayText(rowConfig.year.dateText || "--")) || "--";
+                var yearValueText = belchertown_trim(displayText(rowConfig.year.value || "--")) || "--";
+                var yearValueDetailText = belchertown_trim(displayText(rowConfig.year.valueDetail || ""));
+                var yearDateText = belchertown_trim(displayText(rowConfig.year.dateText || "--")) || "--";
                 var yearDateRaw = rowConfig.year.dateRaw;
                 var rowOptions = rowConfig.options || {};
                 var yearDateHtml = formatSnapshotDateHtml(yearDateRaw, yearDateText, "year", rowOptions);
                 var yearValueHtml = formatValueHtml(yearValueText, yearValueDetailText);
 
-                recordCard.find(".records-record-period--year .records-record-period__label").text(displayText(sectionConfig.yearLabel));
-                recordCard.find(".records-record-period--year .records-record-period__value").html(yearValueHtml);
-                recordCard.find(".records-record-period--year .records-record-period__date").html(yearDateHtml);
+                setElementText(recordCard, ".records-record-period--year .records-record-period__label", displayText(sectionConfig.yearLabel));
+                setElementHtml(recordCard, ".records-record-period--year .records-record-period__value", yearValueHtml);
+                setElementHtml(recordCard, ".records-record-period--year .records-record-period__date", yearDateHtml);
 
                 var fallback = {
                     value: yearValueText,
@@ -754,36 +773,35 @@
                     rowOptions
                 );
 
-                var alltimeValueText = jQuery.trim(displayText(rowConfig.alltime.value || "--")) || "--";
-                var alltimeValueDetailText = jQuery.trim(displayText(rowConfig.alltime.valueDetail || ""));
-                var alltimeDateText = jQuery.trim(displayText(rowConfig.alltime.dateText || "--")) || "--";
+                var alltimeValueText = belchertown_trim(displayText(rowConfig.alltime.value || "--")) || "--";
+                var alltimeValueDetailText = belchertown_trim(displayText(rowConfig.alltime.valueDetail || ""));
+                var alltimeDateText = belchertown_trim(displayText(rowConfig.alltime.dateText || "--")) || "--";
                 var alltimeDateRaw = rowConfig.alltime.dateRaw;
                 var alltimeDateHtml = formatSnapshotDateHtml(alltimeDateRaw, alltimeDateText, "alltime", rowOptions);
                 var alltimeValueHtml = formatValueHtml(alltimeValueText, alltimeValueDetailText);
                 var alltimeLabelText = rowOptions.hideAlltimeLabel ? "" : sectionConfig.alltimeLabel;
-                recordCard.find(".records-record-period--alltime .records-record-period__label").text(displayText(alltimeLabelText));
-                recordCard.find(".records-record-period--alltime .records-record-period__value").html(alltimeValueHtml);
-                recordCard.find(".records-record-period--alltime .records-record-period__date").html(alltimeDateHtml);
+                setElementText(recordCard, ".records-record-period--alltime .records-record-period__label", displayText(alltimeLabelText));
+                setElementHtml(recordCard, ".records-record-period--alltime .records-record-period__value", alltimeValueHtml);
+                setElementHtml(recordCard, ".records-record-period--alltime .records-record-period__date", alltimeDateHtml);
 
-                sectionBody.append(recordCard);
+                if (sectionBody) {
+                    sectionBody.appendChild(recordCard);
+                }
             });
 
-            sectionsContainer.append(section);
+            sectionsContainer.appendChild(section);
         });
     }
 
-    jQuery(document).ready(function() {
-        if (typeof ajaxweewx === "function") {
-            ajaxweewx().then(function(weewxData) {
-                enhanceRecordsPage(weewxData);
-            }).catch(function() {
-                enhanceRecordsPage(null);
-            });
-        } else {
+    if (typeof ajaxweewx === "function") {
+        ajaxweewx().then(function(weewxData) {
+            enhanceRecordsPage(weewxData);
+        }).catch(function() {
             enhanceRecordsPage(null);
-        }
-
-    });
+        });
+    } else {
+        enhanceRecordsPage(null);
+    }
 
     }
 


### PR DESCRIPTION
Final part of the jQuery-removal series (see #237 for the full plan).

The page templates still used jQuery in their inline scripts: the beaufort and last-updated writers on index/kiosk, the chart group/section builders on the charts page, `jQuery.trim` plus jQuery-built section/record cards on the records page, and the updated line on the pi page. This converts them all to the same vanilla helpers the skin scripts now use (`belchertown_set_html`/`belchertown_set_text` from #240, plus a local `belchertown_trim` and element builders on the records page), then removes the jQuery `<script>` tag from `header.html.tmpl` — nothing in the skin references it any more.

Net effect of the series: one less render-blocking CDN request (~30 KB gzipped) on every page, and no dependency on a library Bootstrap 5 made redundant.

Tested on a live weewx 5.1 station and against this branch with the stock example config: home, charts (day and all), records, kiosk and pi all pass an interactive browser regression (snapshot dropdowns, almanac modal, theme toggle, offcanvas menu, radar tabs, chart rendering, MQTT live updates, records cards) in both themes, with `typeof jQuery === "undefined"` and zero console errors on every page.

Stacked on #240 — the template changes are the head commit only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)