### PR TITLE
Add "charts_conf" skin.conf

### DIFF
--- a/bin/user/new_belchertown.py
+++ b/bin/user/new_belchertown.py
@@ -4839,8 +4839,10 @@ class getData(SearchList):
             skin_dict["SKIN_ROOT"],
             skin_dict.get("skin", ""),
         )
+        # Look up the custom filename using "charts_conf" parameter, falling back to the literal "charts.conf"
+        charts_conf_filename = extras_dict.get("charts_conf", "charts.conf")
         legacy_chart_config_path = os.path.join(skin_root_path, "graphs.conf")
-        chart_config_path = os.path.join(skin_root_path, "charts.conf")
+        chart_config_path = os.path.join(skin_root_path, charts_conf_filename)
         default_chart_config_path = os.path.join(skin_root_path, "charts.conf.example")
         if os.path.exists(legacy_chart_config_path):
             log.warning(
@@ -7643,11 +7645,13 @@ class HighchartsJsonGenerator(weewx.reportengine.ReportGenerator):
             self.skin_dict.get("skin", ""),
             "graphs.conf",
         )
+        # Look up the custom filename using "charts_conf" parameter, falling back to the literal "charts.conf"
+        charts_conf_filename = self.skin_dict.get("Extras", {}).get("charts_conf", "charts.conf")
         chart_config_path = os.path.join(
             self.config_dict["WEEWX_ROOT"],
             self.skin_dict["SKIN_ROOT"],
             self.skin_dict.get("skin", ""),
-            "charts.conf",
+            charts_conf_filename,
         )
         default_chart_config_path = os.path.join(
             self.config_dict["WEEWX_ROOT"],

--- a/skins/new-belchertown/skin.conf
+++ b/skins/new-belchertown/skin.conf
@@ -50,6 +50,7 @@
     highcharts_homepage_chartgroup = "homepage"
     highcharts_decimal             = "auto"
     highcharts_thousands           = "auto"
+    charts_conf                    = "charts.conf"
 
     # ----- Live updates and MQTT -----
     mqtt_websockets_enabled         = 0


### PR DESCRIPTION
Localization: Added charts_conf skin option to support language-specific chart configurations.

The [skin.conf Wiki](https://github.com/uajqq/weewx-belchertown-new/wiki/Skin-options) needs to be updated. Under [Chart Options](https://github.com/uajqq/weewx-belchertown-new/wiki/Skin-options#chart-options), I suggest adding another line:

- **Name**
  - `charts_conf`
- **Default**
  - `"charts.conf"`
- **Description**
  - Overrides the default configuration with a language-specific `.conf` file. This allows you to customize chart titles and settings for multiple languages.