### PR TITLE
Show ET as daily sum instead of instantaneous per-interval value

### DIFF
--- a/bin/user/new_belchertown.py
+++ b/bin/user/new_belchertown.py
@@ -7372,6 +7372,21 @@ class getData(SearchList):
 
                 # Empty field for the JSON "current" output
                 obs_output = ""
+            elif obs == "ET":
+                # ET shows daily sum instead of the tiny per-interval instantaneous value
+                obs_binder = weewx.tags.ObservationBinder(
+                    "ET",
+                    archiveDaySpan(current_stamp),
+                    db_lookup,
+                    None,
+                    "day",
+                    self.generator.formatter,
+                    self.generator.converter,
+                )
+                obs_output = getattr(obs_binder, "sum")
+                obs_meta = _unit_switch_station_observation_meta("ET", obs_output)
+                if obs_meta:
+                    station_obs_unit_json["ET"] = obs_meta
             elif obs == "cloud_cover":
                 obs_output = cloud_cover
                 obs_source = EXTERNAL_STATION_OBSERVATION_SOURCES.get(obs)


### PR DESCRIPTION
When I added ET to the station-observations current-conditions, it used the generic getattr(current, obs) path, which returns the instantaneous per-archive-interval value rather than an accumulated total. Since per-interval ET is very small (~0.002 in over 5 min), it consistently rounded to 0.00 in the UI despite non-zero underlying data.

This adds an ET-specific branch (mirroring the existing rainWithRainRate pattern) that computes the day-to-date sum via ObservationBinder, so the tile now shows a meaningful running total that updates each archive cycle.